### PR TITLE
Fix missing ; in GZ_REGISTER_WORLD_PLUGIN

### DIFF
--- a/plugins_hello_world/tutorial-6.md
+++ b/plugins_hello_world/tutorial-6.md
@@ -110,7 +110,7 @@ The only other mandatory function is `Load` which receives an SDF element that
 contains the elements and attributes specified in loaded SDF file.
 
 ~~~
-  GZ_REGISTER_WORLD_PLUGIN(WorldPluginTutorial)
+  GZ_REGISTER_WORLD_PLUGIN(WorldPluginTutorial);
 ~~~
 
 Finally, the plugin must be registered with the simulator using the


### PR DESCRIPTION
The error is also in the big code snippet, but that's not in this file. Not sure if that's auto-generated. :thinking: 