### PR TITLE
Changed the installation command as per the forum

### DIFF
--- a/install_ubuntu/tutorial_11.0.md
+++ b/install_ubuntu/tutorial_11.0.md
@@ -57,13 +57,14 @@ installation](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connec
 
     Next install gazebo-11 by:
 
+        sudo apt-get install libgazebo11
         sudo apt-get install gazebo11
         # For developers that work on top of Gazebo, one extra package
         sudo apt-get install libgazebo11-dev
 
     If you see the error below:
 
-        $ sudo apt-get install gazebo11
+        $ sudo apt-get install libgazebo11
         Reading package lists... Done
         Building dependency tree
         Reading state information... Done


### PR DESCRIPTION
When updating to Gazebo 11, there was error when sudo apt-get install gazebo11 was executed. From further digging in the forums, it was found that it should be actually sudo apt-get libgazebo11 followed by gazebo11.
https://answers.gazebosim.org/question/24607/gazebo-11-installation-problems/
Link to the forum discussion