### PR TITLE
Update gzweb installation tutorial

### DIFF
--- a/gzweb_install/tutorial.md
+++ b/gzweb_install/tutorial.md
@@ -18,19 +18,13 @@ to install Gazebo 9 as follows:
 sudo apt install gazebo9 libgazebo9-dev
 ~~~
 
-Run the following to install the rest of dependencies, including NodeJS:
+Run the following to install dependencies:
 
 ~~~
 sudo apt install libjansson-dev libboost-dev imagemagick libtinyxml-dev mercurial cmake build-essential
 ~~~
 
-Install nodejs
-
-~~~
-sudo apt install nodejs npm
-~~~
-
-If you run into issues with installing `npm`, another option is to install using node's version manager `nvm`. For example, here are the commands for installing nvm and node:
+Next install `nodejs` and `npm` using node's version manager `nvm`:
 
 ~~~
  # install nvm
@@ -42,6 +36,9 @@ If you run into issues with installing `npm`, another option is to install using
  # install node version 6 or above
  nvm install 6
 ~~~
+
+> You may run into conflict with the libssl version needed by Gazebo and nodejs when trying to install using `apt` on Ubuntu.
+So the recommended way of installation is to use `nvm`.
 
 # Build GzWeb
 

--- a/gzweb_install/tutorial_7.md
+++ b/gzweb_install/tutorial_7.md
@@ -6,42 +6,27 @@ on a web browser.
 
 # Dependencies
 
-The main dependencies for GzWeb are the Gazebo development libraries, version 9 or
-greater, and NodeJS version 6 or greater.
+The main dependencies for GzWeb are the Gazebo development libraries, version 7 or
+greater, and NodeJS version 4 up to version 8.
 
 Take a look at
 [these tutorials](http://gazebosim.org/install) to choose the Gazebo
 installation that best fits your case. The simplest approach would be
-to install Gazebo 9 as follows:
+to install Gazebo 7 as follows:
 
 ~~~
-sudo apt install gazebo9 libgazebo9-dev
+sudo apt install gazebo7 libgazebo7-dev
 ~~~
 
 Run the following to install the rest of dependencies, including NodeJS:
 
 ~~~
-sudo apt install libjansson-dev libboost-dev imagemagick libtinyxml-dev mercurial cmake build-essential
+sudo apt install libjansson-dev nodejs npm nodejs-legacy libboost-dev imagemagick libtinyxml-dev mercurial cmake build-essential
 ~~~
 
-Install nodejs
-
-~~~
-sudo apt install nodejs npm
-~~~
-
-If you run into issues with installing `npm`, another option is to install using node's version manager `nvm`. For example, here are the commands for installing nvm and node:
-
-~~~
- # install nvm
- curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-
- # source .bashrc so we can use the nvm cmd
- source ~/.bashrc
-
- # install node version 6 or above
- nvm install 6
-~~~
+> Ubuntu Trusty comes with NodeJS 0.10. You can follow
+  [these](https://github.com/nodesource/distributions) instructions to upgrade
+  the Node version.
 
 # Build GzWeb
 
@@ -49,10 +34,10 @@ If you run into issues with installing `npm`, another option is to install using
 
         cd ~; git clone https://github.com/osrf/gzweb
 
-1. Enter the GzWeb repository and switch to the latest release branch:
+1. Enter the GzWeb repository and switch to the 1.4.0 release branch:
 
         cd ~/gzweb
-        git checkout gzweb_1.4.1
+        git checkout gzweb_1.4.0
 
 1. The first time you build, you'll need to gather all the Gazebo models which
    you want to simulate in the right directory ('http/client/assets') and prepare

--- a/manifest.xml
+++ b/manifest.xml
@@ -471,7 +471,8 @@
 
     <tutorial title="Gzweb installation" ref='gzweb_install'>
       <markdown version="1.9+">gzweb_install/tutorial_1.9.md</markdown>
-      <markdown version="7+">gzweb_install/tutorial.md</markdown>
+      <markdown version="7+">gzweb_install/tutorial_7.md</markdown>
+      <markdown version="9+">gzweb_install/tutorial.md</markdown>
       <description>Explains how to install and run the WebGL client for Gazebo.</description>
       <skill>beginner</skill>
     </tutorial>


### PR DESCRIPTION
Added a new tutorial for gazebo versions 9 or above

Main changes are:
* added additional instructions for installing nodejs
* updated instruction to use gzweb_1.4.1 release

Signed-off-by: Ian Chen <ichen@osrfoundation.org>