### PR TITLE
Add ROS-Noetic Debian Install Instructions

### DIFF
--- a/ros_installing/tutorial.md
+++ b/ros_installing/tutorial.md
@@ -92,6 +92,12 @@ sudo apt-get install ros-kinetic-gazebo-ros-pkgs ros-kinetic-gazebo-ros-control
 sudo apt-get install ros-indigo-gazebo-ros-pkgs ros-indigo-gazebo-ros-control
 ~~~
 
+* [ROS Noetic](http://ros.org/wiki/noetic):
+
+~~~
+sudo apt-get install ros-noetic-gazebo-ros-pkgs ros-noetic-gazebo-ros-control
+~~~
+
 If this installation method ends successfully for you, jump to the Testing Gazebo with ROS Integration section below.
 
 ### B. Install from Source (on Ubuntu)

--- a/ros_installing/tutorial.md
+++ b/ros_installing/tutorial.md
@@ -74,6 +74,18 @@ bug patches ;-)
 
 The `gazebo_ros_pkgs` packages are available in:
 
+* [ROS Noetic](http://ros.org/wiki/noetic):
+
+~~~
+sudo apt-get install ros-noetic-gazebo-ros-pkgs ros-noetic-gazebo-ros-control
+~~~
+
+* [ROS Melodic](http://ros.org/wiki/melodic):
+
+~~~
+sudo apt-get install ros-melodic-gazebo-ros-pkgs ros-melodic-gazebo-ros-control
+~~~
+
 * [ROS Lunar](http://ros.org/wiki/lunar):
 
 ~~~
@@ -92,11 +104,6 @@ sudo apt-get install ros-kinetic-gazebo-ros-pkgs ros-kinetic-gazebo-ros-control
 sudo apt-get install ros-indigo-gazebo-ros-pkgs ros-indigo-gazebo-ros-control
 ~~~
 
-* [ROS Noetic](http://ros.org/wiki/noetic):
-
-~~~
-sudo apt-get install ros-noetic-gazebo-ros-pkgs ros-noetic-gazebo-ros-control
-~~~
 
 If this installation method ends successfully for you, jump to the Testing Gazebo with ROS Integration section below.
 


### PR DESCRIPTION
Tested this on Ubuntu 20.04 with ROS Kinetic and it worked perfectly. These instructions are desperately needed for new beginners, would be really awesome if they could be incorporated 🙂.