### PR TITLE
Update tutorial_9-0.md

### DIFF
--- a/install_on_windows/tutorial_9-0.md
+++ b/install_on_windows/tutorial_9-0.md
@@ -90,6 +90,13 @@ Windows `cmd` for configuring and building.  You might also need to
    or
         "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
+Note:   Replace 2017 with 2019 in the path if running VS 2019
+
+        "C:\Program Files\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+
+   or
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+
 1. In a Windows shell, configure and build Ignition CMake
 
         cd ign-cmake


### PR DESCRIPTION
Copying line 89 or 92 implicitly for VS version higher than 2017 won't let cmd locate vcvarsall.bat as intended.