### PR TITLE
Update tutorial_default.md

### DIFF
--- a/install_from_source/tutorial_default.md
+++ b/install_from_source/tutorial_default.md
@@ -61,10 +61,6 @@ the default branch. In an Ubuntu system, several Personal Package Archives
 (PPA's) can be used to install the proper package and dependencies. Note that
 adding these PPA's may cause conflicts with ROS.
 
-    # Only needed on Trusty. Ubuntu packages since Utopic.
-    sudo apt-add-repository ppa:libccd-debs
-    sudo apt-add-repository ppa:fcl-debs
-
     # Main repository
     sudo apt-add-repository ppa:dartsim
     sudo apt-get update


### PR DESCRIPTION
Hey, my first PR, worked on issue#133, which stated to remove references to trusty - specific steps for install from source tutorial for gazebo >= 9, as gazebo >= 9 does not support Trusty. So removing the steps to avoid confusion for the new users.