### PR TITLE
Update node version in gzweb_install tutorial

### DIFF
--- a/gzweb_install/tutorial.md
+++ b/gzweb_install/tutorial.md
@@ -33,8 +33,8 @@ Next install `nodejs` and `npm` using node's version manager `nvm`:
  # source .bashrc so we can use the nvm cmd
  source ~/.bashrc
 
- # install node version 6 or above
- nvm install 6
+ # install node. Supported versions are 8 to 11. 
+ nvm install 8
 ~~~
 
 > You may run into conflict with the libssl version needed by Gazebo and nodejs when trying to install using `apt` on Ubuntu.


### PR DESCRIPTION
Hey, the node version specified in the gzweb_install tutorial didn't work osrf/gzweb#217 osrf/gzweb#173 . I tested it on Ubuntu 18.04 amd64 with gazebo 9 and have updated the version.

v6.17.1 (npm v3.10.10): Build Error
v7.10.1 (npm v4.2.0): Build Error
```
gzweb/node_modules/micromatch/index.js:44
    let isMatch = picomatch(String(patterns[i]), { ...options, onResult }, true);
                                                   ^^^

SyntaxError: Unexpected token ...
```

v8.17.0 (npm v6.13.4): Build OK, Run OK
v9.11.2 (npm v5.6.0): Build OK, Run OK
v10.24.1 (npm v6.14.12): Build OK, Run OK [Deprecation Warnings]
v11.15.0 (npm v6.7.0): Build OK, Run OK [Deprecation Warnings]

v12.22.1 (npm v6.14.12): Build Error
```
In file included from ../GZNode.cc:19:0:
../GZNode.hh:36:30: error: ‘v8::Handle’ has not been declared
     public: static void Init(v8::Handle<v8::Object> exports);
```

The version 1.4.1 in the tutorial needs to have osrf/gzweb#205 applied so I kept it out of the list.