### PR TITLE
Update laser template to include <vertical> tags

### DIFF
--- a/ros_gzplugins/tutorial.md
+++ b/ros_gzplugins/tutorial.md
@@ -428,6 +428,12 @@ Now we'll add the plugin information to `rrbot.gazebo`, again as we did for the 
             <min_angle>-1.570796</min_angle>
             <max_angle>1.570796</max_angle>
           </horizontal>
+	  <vertical>
+            <samples>2</samples>
+            <resolution>1.0</resolution>
+            <min_angle>-0.001</min_angle>
+            <max_angle>0.001</max_angle>
+          </vertical>
         </scan>
         <range>
           <min>0.10</min>


### PR DESCRIPTION
The default vertical field of view is high enough that the laser rays have unwanted intersections with the robot's collision faces.
![gazebo_laser_issue](https://user-images.githubusercontent.com/47291559/123731186-c6d9aa80-d8eb-11eb-89db-dea009ac6131.gif)


This causes the laser scan message to report an obstacle at a close distance, which messes with navigation.

![gazebo_laser_issue_rviz](https://user-images.githubusercontent.com/47291559/123731380-2041d980-d8ec-11eb-90e2-9e42530b5095.gif)


After setting the vertical tags as per the commit, the problem is gone and laser plugin behaves as expected.

![Screenshot from 2021-06-29 15-01-18](https://user-images.githubusercontent.com/47291559/123730718-f340f700-d8ea-11eb-8ec0-5461629f892d.png)

