### PR TITLE
Update Gazebo version references in Linux install pages

### DIFF
--- a/install_other_linux/tutorial.md
+++ b/install_other_linux/tutorial.md
@@ -8,30 +8,28 @@ Debian, Fedora, Arch and Gentoo.
 ## Debian
 
 [Gazebo in Debian](https://packages.debian.org/source/sid/gazebo) is available
-as an official package since stretch. Debian Sid (the Gazebo team is the official
+as an official package since Stretch. Debian Sid (the Gazebo team is the official
 maintainer in Debian) usually hosts the latest gazebo release. Depending on the
 Debian version the version of Gazebo available is different:
 
  * Debian Sid is usually hosting one of the latest releases
  * Debian Buster: gazebo-9.6.0
- * Debian Stretch: gazebo-7.3.1
+ * Debian Bullseye: gazebo-11.1.0
 
-1. Install Gazebo9 (on Buster)
+1. Install Gazebo11 (on Bullseye)
 
-        sudo apt-get install gazebo9
+        sudo apt-get install gazebo11
         # For developers that works on top of Gazebo, one extra package
-        sudo apt-get install libgazebo9-dev
+        sudo apt-get install libgazebo11-dev
 
 ## Fedora
 
 [Gazebo in Fedora](https://apps.fedoraproject.org/packages/gazebo) is available
-as an official package (the maintainer is Rich Mattes). Depending on the Fedora
-version, the version of Gazebo available is different:
+as an official package.
 
- * Rawhide is usually hosting one of the latest releases
- * Fedora 31: gazebo-9.x
- * Fedora 30: gazebo-9.x
- * Fedora 29: gazebo-8.x
+ * Rawhide: gazebo-10
+ * Fedora 35: gazebo-10.x
+ * Fedora 36: gazebo-10.x
 
 1. Install Gazebo
         sudo dnf install gazebo gazebo-ode
@@ -46,15 +44,15 @@ is not in the official package repositories and users need to compile it from
 source. The easiest way to install it is to use an AUR helper, such as yaourt
 or packer:
 
-1. Install Gazebo
+1. Install Gazebo11
 
         yaourt -S gazebo
         # or
         sudo packer -S gazebo
 
-## Gentooo
+## Gentoo
 
-[Gazebo in Gentoo](https://packages.gentoo.org/package/sci-electronics/gazebo)
+[Gazebo11 in Gentoo](https://packages.gentoo.org/package/sci-electronics/gazebo)
 is available as an official package (the maintainer is Alexis Ballier). It is
 currently masked as ~amd64 so please read about how to [mix software
 branches](https://wiki.gentoo.org/wiki/Handbook:AMD64/Portage/Branches) if you
@@ -66,7 +64,7 @@ gentoolkit) to know more about the optional support:
       emerge --ask app-portage/gentoolkit
       equery uses gazebo -a
 
-1. Install Gazebo on stable branch
+1. Install Gazebo11 on stable branch
 
         echo "sci-electronics/gazebo" >> /etc/portage/package.accept_keywords
         emerge gazebo
@@ -77,6 +75,6 @@ gentoolkit) to know more about the optional support:
 
 ## Other linux distributions?
 
-If you know of any other Linux distribution supporting Gazebo installation,
-feel free to [create an issue](https://github.com/osrf/gazebo_tutorials/issues)
-to expand this tutorial.
+There is a large list of Gazebo packages available in many different
+distributions, checking the great
+[repology](https://repology.org/project/gazebo/versions) project can help.

--- a/install_ubuntu/tutorial_11.0.md
+++ b/install_ubuntu/tutorial_11.0.md
@@ -61,35 +61,6 @@ installation](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connec
         # For developers that work on top of Gazebo, one extra package
         sudo apt-get install libgazebo11-dev
 
-    If you see the error below:
-
-        $ sudo apt-get install gazebo11
-        Reading package lists... Done
-        Building dependency tree
-        Reading state information... Done
-        E: Unable to locate package gazebo11
-
-    It's possible the version of Gazebo you are looking for is not supported on the version of OS you are using.
-    For example, installing gazebo11 on Ubuntu Xenial (16.04) will produce the error above.
-    Hint: Take a look at "Project Status" section at [http://gazebosim.org/#status](http://gazebosim.org/#status),
-    next to each version is the supported ubuntu versions and ROS versions.
-
-
 1. Check your installation
 
         gazebo
-
-## Gazebo in different deb packages
-
-Gazebo ships different Ubuntu debian packages following the [official packaging
-guidelines](https://www.debian.org/doc/manuals/maint-guide/):
-
- * Use Gazebo as an application: for the users that just run Gazebo simulator
-   with the provided plugins and models and do not plan on developing on top of
-   gazebo its own custom software. To use Gazebo 11 please install the package
-   called ***gazebo11***.
-
- * Use Gazebo to develop software using Gazebo libraries: for users that
-   develop plugins or any other kind of software that needs Gazebo headers and
-   libraries. In this case, together with gazebo11 package, please install
-   ***libgazebo11-dev***.

--- a/install_ubuntu/tutorial_9-0.md
+++ b/install_ubuntu/tutorial_9-0.md
@@ -67,7 +67,7 @@ installation](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connec
         E: Unable to locate package gazebo9
 
     It's possible the version of Gazebo you are looking for is not supported on the version of OS you are using.
-    For example, installing gazebo9 on Ubuntu Trusty (14.04) will produce the error above.
+    For example, installing gazebo9 on Ubuntu Jammy (22.04) will produce the error above.
     Hint: Take a look at "Project Status" section at [http://gazebosim.org/#status](http://gazebosim.org/#status),
     next to each version is the supported ubuntu versions and ROS versions.
 
@@ -77,18 +77,3 @@ installation](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connec
     ***Note*** The first time `gazebo` is executed requires the download of some models and it could take some time, please be patient.
 
         gazebo
-
-## Gazebo in different deb packages
-
-Gazebo ships different Ubuntu debian packages following the [official packaging
-guidelines](https://www.debian.org/doc/manuals/maint-guide/):
-
- * Use Gazebo as an application: for the users that just run Gazebo simulator
-   with the provided plugins and models and do not plan on developing on top of
-   gazebo its own custom software. To use Gazebo 9 please install the package
-   called ***gazebo9***.
-
- * Use Gazebo to develop software using Gazebo libraries: for users that
-   develop plugins or any other kind of software that needs Gazebo headers and
-   libraries. In this case, together with gazebo9 package, please install
-   ***libgazebo9-dev***.

--- a/install_unstable/tutorial.md
+++ b/install_unstable/tutorial.md
@@ -23,7 +23,7 @@ sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `ls
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
 wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install gazebo10 # (might not be released)
+sudo apt-get install gazebo11
 ```
 
 ### Gazebo nightly repo
@@ -38,7 +38,7 @@ sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `ls
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list'
 wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install gazebo10 # (might not be released)
+sudo apt-get install gazebo11
 ```
 
 ### Remove prereleases and nightly installed packages


### PR DESCRIPTION
Give the install documents a good update on versions available. Simplify the Ubuntu page by removing outdated warnings and info.