### PR TITLE
Update ros installation instructions to supported ROS versions

### DIFF
--- a/ros_installing/tutorial.md
+++ b/ros_installing/tutorial.md
@@ -6,10 +6,9 @@ See [Overview of new ROS integration](http://gazebosim.org/tutorials/?tut=ros_ov
 for background information before continuing here.
 
 These instructions are for using the Gazebo versions that are fully integrated
-with ROS [Noetic](http://www.ros.org/wiki/noetic), ROS [Lunar](http://www.ros.org/wiki/lunar), ROS
-[Kinetic](http://www.ros.org/wiki/kinetic) and ROS
-[Indigo](http://www.ros.org/wiki/indigo).  It is recommended to first read
-[Which combination of ROS/Gazebo version to use](http://gazebosim.org/tutorials/?tut=ros_wrapper_versions)
+with ROS [Noetic](http://www.ros.org/wiki/noetic),
+[Melodic](http://www.ros.org/wiki/melodic) and ROS.  It is recommended to first
+read [Which combination of ROS/Gazebo version to use](http://gazebosim.org/tutorials/?tut=ros_wrapper_versions)
 before going on with this tutorial. Depending on your needs, you could need an
 alternative installation.
 
@@ -20,8 +19,8 @@ You should understand the basic concepts of ROS and have gone through the [ROS T
 ### Install ROS
 
 We recommend for these ROS integration tutorials you install
-(`ros-noetic-desktop-full`, `ros-lunar-desktop-full`, `ros-kinetic-desktop-full` or
-`ros-indigo-desktop-full`) so that you have all the necessary packages.
+(`ros-noetic-desktop-full` or `ros-melodic-desktop-full`) so
+that you have all the necessary packages.
 
 See the [ROS installation page](http://www.ros.org/wiki/ROS/Installation) for more details. Be sure to source your ROS setup.bash script by following the instructions on the ROS installation page.
 
@@ -80,7 +79,6 @@ bug patches ;-)
 
 The `gazebo_ros_pkgs` packages are available in:
 
-=======
 * [ROS Noetic](http://ros.org/wiki/noetic):
 
 ~~~
@@ -93,19 +91,7 @@ sudo apt-get install ros-noetic-gazebo-ros-pkgs ros-noetic-gazebo-ros-control
 sudo apt-get install ros-melodic-gazebo-ros-pkgs ros-melodic-gazebo-ros-control
 ~~~
 
-* [ROS Kinetic](http://ros.org/wiki/kinetic):
-
-~~~
-sudo apt-get install ros-kinetic-gazebo-ros-pkgs ros-kinetic-gazebo-ros-control
-~~~
-
 If this installation method ends successfully for you, jump to the Testing Gazebo with ROS Integration section below.
-
-### B. Install from Source (on Ubuntu)
-
-If you are running an earlier version of ROS (Groovy or earlier) you will need
-to install `gazebo_ros_pkgs` from source. Installing from source is also useful
-if you want to develop new plugins or submit patches.
 
 #### Setup A Catkin Workspace
 
@@ -137,32 +123,32 @@ Make sure `git` is installed on your Ubuntu machine:
 sudo apt-get install git
 ~~~
 
-##### ROS Kinetic
+##### ROS Noetic
 
-Kinetic is using the gazebo 7.x series, start by installing it:
+Noetic is using the gazebo 11.x series, start by installing it:
 
 ~~~
-sudo apt-get install -y libgazebo7-dev
+sudo apt-get install -y libgazebo11-dev
 ~~~
 
 Download the source code from the [`gazebo_ros_pkgs` github repository](https://github.com/ros-simulation/gazebo_ros_pkgs):
 
 ~~~
 cd ~/catkin_ws/src
-git clone https://github.com/ros-simulation/gazebo_ros_pkgs.git -b kinetic-devel
+git clone https://github.com/ros-simulation/gazebo_ros_pkgs.git -b noetic-devel
 ~~~
 
 Check for any missing dependencies using rosdep:
 
 ~~~
 rosdep update
-rosdep check --from-paths . --ignore-src --rosdistro kinetic
+rosdep check --from-paths . --ignore-src --rosdistro noetic
 ~~~
 
 You can automatically install the missing dependencies using rosdep via debian install:
 
 ~~~
-rosdep install --from-paths . --ignore-src --rosdistro kinetic -y
+rosdep install --from-paths . --ignore-src --rosdistro noetic -y
 ~~~
 
 Now jump to the [build the gazebo\_ros\_pkgs](#Buildthegazebo_ros_pkgs) section.
@@ -180,10 +166,10 @@ See [answers.gazebosim.org](http://answers.gazebosim.org/questions/) for issues 
 
 ## Testing Gazebo with ROS Integration
 
-Be sure to always source the appropriate ROS setup file, which for Kinetic is done like so:
+Be sure to always source the appropriate ROS setup file, which for Noetic is done like so:
 
 ~~~
-source /opt/ros/kinetic/setup.bash
+source /opt/ros/noetic/setup.bash
 ~~~
 
 You might want to add that line to your `~/.bashrc`.

--- a/ros_wrapper_versions/tutorial.md
+++ b/ros_wrapper_versions/tutorial.md
@@ -20,7 +20,7 @@ repositories could end up in conflicts or other integration problems with ROS pa
 Gazebo is an independent project like boost, ogre or
 any other project used by ROS. Usually, the latest major version of gazebo
 available at the beginning of every ROS release cycle (for example `gazebo11`
-for ROS Kinetic) is selected as the official one to be fully integrated and
+for ROS Noetic) is selected as the official one to be fully integrated and
 supported and will be kept during the whole life of the ROS distribution.
 
 Gazebo development is not synced with ROS, so each new major version of Gazebo
@@ -40,16 +40,12 @@ the same ROS distro.
 The easiest way of installing Gazebo is to use packages. There are two main repositories which host Gazebo packages: one is `packages.ros.org` and the other is `packages.osrfoundation.org`. At the time of writing:
 
  * ***packages.ros.org***
-  *  ROS Kinetic: Gazebo 7.x
   *  ROS Melodic: Gazebo 9.x
   *  ROS Noetic: Gazebo 11.x
-  *  ROS2 Dashing: Gazebo 9.x
-  *  ROS2 Eloquent: Gazebo 9.x
   *  ROS2 Foxy: Gazebo 11.x
+  *  ROS2 Rolling: Gazebo 11.x
  * ***packages.osrfoundation.org***
-  * gazebo 7.x series (package name `gazebo7`)
   * gazebo 9.x series (package name `gazebo9`)
-  * gazebo 10.x series (package name `gazebo10`)
   * gazebo 11.x series (package name `gazebo11`)
 
 This means that including the osrfoundation repository is not strictly needed to get the Gazebo Ubuntu package.
@@ -58,12 +54,12 @@ It can be installed from the ros repository.
 ### Gazebo built from source
 
 If you have compiled a gazebo version from source, note that depending on the
-repository branch used (`gazebo7`,`gazebo9`,...) your gazebo will be
+repository branch used (`gazebo9` or `gazebo11`) your gazebo will be
 binary compatible with the `gazebo_ros_pkgs` (and all other ROS packages compiled
 on top of gazebo) only if the major version matches your local branch
 repository and the gazebo version used in your ROS distro.  For example, if you
-are compiling from gazebo branch `gazebo9`, you can use the `gazebo_ros_pkgs`
-present in Melodic (which uses gazebo9 series).
+are compiling from gazebo branch `gazebo11`, you can use the `gazebo_ros_pkgs`
+present in Noetic (which uses gazebo11 series).
 
 Note that if you are using `default` branch, you are probably not binary
 compatible with any of the packages released, so you will need a catkin
@@ -75,25 +71,11 @@ For the users that need to run a specific version of ROS
  and want to use all the gazebo ROS related packages out-of-the-box,
  this is the recommended section:
 
-### ROS2 Foxy
-ROS2 Foxy hosts or use the 11.x version of Gazebo.
+### ROS2 Foxy and ROS2 Rolling
+ROS2 Foxy and ROS2 Rolling host or use the 11.x version of Gazebo.
 For a fully-integrated ROS system, we recommend using the 11.x version of
 Gazebo.  The way to proceed is just to use the ROS repository (it will
 automatically install `gazebo11`) and do ***not*** use the osrfoundation
-repository.
-
-### ROS2 Eloquent
-ROS2 Eloquent hosts or use the 9.x version of Gazebo.
-For a fully-integrated ROS system, we recommend using the 9.x version of
-Gazebo.  The way to proceed is just to use the ROS repository (it will
-automatically install `gazebo9`) and do ***not*** use the osrfoundation
-repository.
-
-### ROS2 Dashing
-ROS2 Dashing hosts or use the 9.x version of Gazebo.
-For a fully-integrated ROS system, we recommend using the 9.x version of
-Gazebo.  The way to proceed is just to use the ROS repository (it will
-automatically install `gazebo9`) and do ***not*** use the osrfoundation
 repository.
 
 ### ROS1 Noetic
@@ -110,46 +92,27 @@ Gazebo.  The way to proceed is just to use the ROS repository (it will
 automatically install `gazebo9`) and do ***not*** use the osrfoundation
 repository.
 
-### ROS1 Kinetic
-
-ROS Kinetic hosts or use the 7.x version of Gazebo.
-For a fully-integrated ROS system, we recommend using the 7.x version of
-Gazebo.  The way to proceed is just to use the ROS repository (it will
-automatically install `gazebo7`) and do ***not*** use the osrfoundation
-repository.
-
 ## Using a specific Gazebo version with ROS
 ***Warning!: Using this option, you won't be able to use any ROS Ubuntu package
 related to Gazebo from ROS deb repository.  The equivalent of `gazebo_ros_pkgs`
 can be installed from debian packages, but all other software (such as
 [turtlebot_gazebo](http://wiki.ros.org/turtlebot_gazebo)) must be built from
 source.  Thanks to [catkin workspaces](http://wiki.ros.org/catkin/Tutorials/create_a_workspace)
+or [colcon workspaces](https://docs.ros.org/en/rolling/Tutorials/Workspace/Creating-A-Workspace.html)
 this is quite easy to do.***
 
 There is a way of using any specific version of gazebo and ROS if really needed:
 
 ### Gazebo 11.x series
 
-The OSRF repository provides `-gazebo11-` versions of ROS/Melodic, ROS2/Dashing
-or ROS2/Eloquent gazebo wrappers (`gazebo11_ros_pkgs`) which are built on top of
+The OSRF repository provides `-gazebo11-` versions of ROS/Melodic or
+ROS2/Eloquent gazebo wrappers (`gazebo11_ros_pkgs`) which are built on top of
 the `gazebo11` package.  The steps to use them are:
 
  * Add the osrfoundation repository to your sources list.
  * Install `ros-$ROS_DISTRO-gazebo11-ros-pkgs` and/or `ros-$ROS_DISTRO-gazebo11-ros-control`
    from the osrfoundation repository, which will install the `gazebo11` package.
  * Use catkin workspaces to compile the rest of the software used from source.
-
-### Gazebo 9.x series
-
-The OSRF repository provides `-gazebo9-` versions of ROS/Kinetic gazebo
-wrappers (`gazebo9_ros_pkgs`) which are built on top of the `gazebo9` package.
-The steps to use them are:
-
- * Add the osrfoundation repository to your sources list.
- * Install `ros-$ROS_DISTRO-gazebo9-ros-pkgs` and/or `ros-$ROS_DISTRO-gazebo9-ros-control`
-   from the osrfoundation repository, which will install the `gazebo9` package.
- * Use catkin workspaces to compile the rest of the software used from source.
-
 
 ## FAQ
 
@@ -158,8 +121,8 @@ The steps to use them are:
 If you don't need ROS support, the recommended version is the latest released version that can be
  [installed using the osrfoundation repo](http://gazebosim.org/install).
 
-#### I need to use gazebo11 and ROS Melodic/Dashing/Eloquent, what can I do?
-***Warning!: Using this option, you won't be able to use any ROS Kinetic package
+#### I need to use gazebo11 and ROS Melodic what can I do?
+***Warning!: Using this option, you won't be able to use any ROS Melodic package
 related to Gazebo from ROS deb repository. The way to go is to build them from
 source. Thanks to catkin workspaces this is quite easy to do.***
 


### PR DESCRIPTION
Quick update for ROS related installations and wrappers. Remove unsupported versions of ROS, ROS 2 and Gazebo.