### PR TITLE
Update tutorial.md

### DIFF
--- a/ros_overview/tutorial.md
+++ b/ros_overview/tutorial.md
@@ -74,7 +74,7 @@ Add dependency on the new `gazebo_ros` package:
 
 ~~~
 <build_depend>gazebo_ros</build_depend>
-<run_depend>gazebo_ros</run_depend>
+<exec_depend>gazebo_ros</exec_depend>
 ~~~
 
 ### Running Gazebo


### PR DESCRIPTION
the <run_depend> tag was replaced by <exec_depend>
Source: https://answers.ros.org/question/283123/what-is-the-difference-between-exec_depend-and-run_depend/