### PR TITLE
Add missing tag to install dependencies tutorial

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -164,6 +164,9 @@
       <markdown version="5 - 8">install_dependencies_from_source/tutorial-8.md</markdown>
       <markdown version="9+">install_dependencies_from_source/tutorial.md</markdown>
       <description>Install some dependencies from source, such as SDFormat and Ignition libraries.</description>
+      <tags>
+        <tag>install</tag>
+      </tags>
       <skill>beginner</skill>
     </tutorial>
 


### PR DESCRIPTION
The install category has been broken for a while. I haven't looked into the web app code, but I noticed there's one install tutorial that's not tagged. Maybe that makes a difference? 