### PR TITLE
Fix error when loading the `install` category

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1080,9 +1080,6 @@
         <tutorial>install_on_mac</tutorial>
         <tutorial>install_on_windows</tutorial>
 
-        <!-- keep name for historical reasons -->
-        <tutorial>install</tutorial>
-
         <tutorial>install_from_source</tutorial>
         <tutorial>install_dependencies_from_source</tutorial>
         <tutorial>install_unstable</tutorial>


### PR DESCRIPTION
The removed `install` ref was causing an error when loading the `install` category. The ref used to exist back in 97daa3bfbf5757f16aae545de97c65e971f5e172 and earlier, but the corresponding tutorial was removed in #157.

I've tested this locally and it fixes the loading issue for me.