### PR TITLE
Add a note about arm version of Gazebo11 on Jammy

### DIFF
--- a/install_ubuntu/tutorial_11.0.md
+++ b/install_ubuntu/tutorial_11.0.md
@@ -18,6 +18,13 @@ Some notes:
     new platforms. The upstream code will keep accepting patches for new
     software versions so from-source installations will also be an option.
 
+  * On Ubuntu Jammy (22.04) [Gazebo](https://packages.ubuntu.com/jammy/science/gazebo)
+    binaries are only available for amd64. ROS uses Ubuntu official packages for Gazebo
+    so there are only amd64 ROS packages. Packages for arm64. armhf and ppc64
+    were released for the same version in Jammy in a
+    [PPA https://launchpad.net/~openrobotics/+archive/ubuntu/gazebo11-non-amd64](https://launchpad.net/~openrobotics/+archive/ubuntu/gazebo11-non-amd64)
+    but there is no official support nor updates for these binaries.
+
   * If you are a [ROS](http://ros.org) user, please read the tutorial about the
     [ROS/Gazebo installation](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connect_ros).
 


### PR DESCRIPTION
Closes: https://github.com/gazebosim/gazebo-classic/issues/3236

ROS is not going to import arm versions of Gazebo11 for the following reasons:
 * Gazebo11 is going to be replaced by then new Gazebo, migration is recommended as soon as possible and the efforts will be focused in the new version.
 * The version in the PPA is not exactly the same than in Ubuntu since it needed some custom patches since some of its dependencies were not available on Ubuntu Jammy.

The packages in the PPA can be used without any guarantee, they probably will work as expected but there is no official support for them. If you are using ROS for `gazebo_ros_pkgs`, there won't be packages for arm64 or amrhf but you can use the PPA to build them from source using a colcon/catkin workspace easily.