### PR TITLE
Update tutorial.md -> Fixed link

### DIFF
--- a/components/tutorial.md
+++ b/components/tutorial.md
@@ -148,4 +148,4 @@ For example, to load the `TimerGUIPlugin`:
 gzclient --gui-client-plugin libTimerGUIPlugin.so
 ~~~
 
-For more information refer to the [plugins overview](http://gazebosim.org/tutorials/?tut=plugins_hello_world) page.
+For more information refer to the [plugins overview](http://classic.gazebosim.org/tutorials/?tut=plugins_hello_world) page.


### PR DESCRIPTION
The old link points to the new domain and leads to nothing.