### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gazebo Tutorials #
 
-This repository contains the source for each gazebo tutorial found on [Gazebo Tutorials](http://gazebosim.org/tutorials).
+This repository contains the source for each gazebo tutorial found on [Gazebo Tutorials](http://classic.gazebosim.org/tutorials).
 
 ## Tips for creating tutorials
 

--- a/actor/tutorial.md
+++ b/actor/tutorial.md
@@ -18,7 +18,7 @@ environment.
 # Actors
 
 In Gazebo, an animated model is called an `actor`. Actors extend
-[common models](http://gazebosim.org/tutorials?tut=build_model&cat=build_robot),
+[common models](/tutorials?tut=build_model&cat=build_robot),
 adding animation capabilities.
 
 There are two types of animations which can be used separately or combined
@@ -39,7 +39,7 @@ moves in the world:
     [[file:files/skel_traj_full.gif|300px]]
 
 Gazebo's actors are just like
-[models](http://gazebosim.org/tutorials?tut=build_model),
+[models](/tutorials?tut=build_model),
 so you can put links and joints inside them as usual. The main differences are:
 
 * Actors are always static (i.e. no forces are applied on them, be it from
@@ -180,7 +180,7 @@ fluid motion, but the exact poses contained in the waypoints might not be reache
 
 > **Tip**: Non-actor models can also follow scripted trajectories, but that
 requires the use of plugins. See
-[this](http://gazebosim.org/tutorials?tut=animated_box)
+[this](/tutorials?tut=animated_box)
 tutorial to learn how.
 
 Now it's your turn! Try out different trejctory descriptions before moving on to
@@ -225,7 +225,7 @@ The actor in the example above is really simple, all it loads is a COLLADA file
 described within the `<skin>` tag.
 
 > **Note**: If you've made
-[custom](http://gazebosim.org/tutorials?tut=import_mesh&cat=build_robot)
+[custom](/tutorials?tut=import_mesh&cat=build_robot)
 Gazebo models before, you might have used COLLADA files as visuals and
 collisions for your models. When used within *links*, COLLADA animations are
 ignored, but when used within *skins*, they are loaded!
@@ -236,7 +236,7 @@ The file specified in `<filename>` can be an absolute path, for example:
 
 You can also tell Gazebo to look for the mesh in all the directories contained in
 the environment variable
-[`GAZEBO_MODEL_PATH`](http://gazebosim.org/tutorials?tut=components),
+[`GAZEBO_MODEL_PATH`](/tutorials?tut=components),
 like this:
 
     model://skeketon_model/skeleton.dae
@@ -396,7 +396,7 @@ take a look at an example of how to change the trajectory dinamically using
 plugins.
 
 > **Tip**: If you're not familiar with Gazebo plugins, take a look at some
-[plugin tutorials](http://gazebosim.org/tutorials?cat=write_plugin) first.
+[plugin tutorials](/tutorials?cat=write_plugin) first.
 
 Gazebo has an example world with actors moving around while avoiding obstacles.
 Take a look at it running:

--- a/add_laser/tutorial.md
+++ b/add_laser/tutorial.md
@@ -1,6 +1,6 @@
 # Overview
 
-**Prerequisites:** [Attach a Mesh as Visual](http://gazebosim.org/tutorials/?tut=attach_meshes)
+**Prerequisites:** [Attach a Mesh as Visual](/tutorials/?tut=attach_meshes)
 
 This tutorials demonstrates how the user can create composite models directly
 from other models in the
@@ -75,4 +75,4 @@ Adding a laser to a robot, or any model, is simply a matter of including the sen
 
 ## Next
 
-[Next: Make a Simple Gripper](http://gazebosim.org/tutorials/?tut=simple_gripper)
+[Next: Make a Simple Gripper](/tutorials/?tut=simple_gripper)

--- a/add_laser/tutorial_6+.md
+++ b/add_laser/tutorial_6+.md
@@ -1,6 +1,6 @@
 # Overview
 
-**Prerequisites:** [Attach a Mesh as Visual](http://gazebosim.org/tutorials/?tut=attach_meshes)
+**Prerequisites:** [Attach a Mesh as Visual](/tutorials/?tut=attach_meshes)
 
 This tutorials demonstrates how the user can create composite models directly
 from other models in the
@@ -68,4 +68,4 @@ Adding a laser to a robot, or any model, is simply a matter of including the sen
 
 ## Next
 
-[Next: Make a Simple Gripper](http://gazebosim.org/tutorials/?tut=simple_gripper)
+[Next: Make a Simple Gripper](/tutorials/?tut=simple_gripper)

--- a/attach_gripper/tutorial-1.9+.md
+++ b/attach_gripper/tutorial-1.9+.md
@@ -2,9 +2,9 @@
 
 **Prerequisites:**
 
-  [Make a Mobile Robot](http://gazebosim.org/tutorials/?tut=build_robot)
+  [Make a Mobile Robot](/tutorials/?tut=build_robot)
 
-  [Make a Simple Gripper](http://gazebosim.org/tutorials/?tut=simple_gripper)
+  [Make a Simple Gripper](/tutorials/?tut=simple_gripper)
 
 This tutorial explains how to create a composite robot from existing robot parts, i.e. mobile base, simple arm and simple gripper.
 
@@ -14,7 +14,7 @@ Start up gazebo and make sure you can load the models from the two previous tuto
 
 ## Mobile Base
 
-1. Per instructions in [Make a Mobile Robot](http://gazebosim.org/tutorials/?tut=build_robot) tutorial, you should have a mobile base robot at your disposal:
+1. Per instructions in [Make a Mobile Robot](/tutorials/?tut=build_robot) tutorial, you should have a mobile base robot at your disposal:
 
     [[file:files/Mobile_base.png|640px]]
 

--- a/attach_gripper/tutorial.md
+++ b/attach_gripper/tutorial.md
@@ -2,9 +2,9 @@
 
 **Prerequisites:**
 
-  [Make a Mobile Robot](http://gazebosim.org/tutorials/?tut=build_robot)
+  [Make a Mobile Robot](/tutorials/?tut=build_robot)
 
-  [Make a Simple Gripper](http://gazebosim.org/tutorials/?tut=simple_gripper)
+  [Make a Simple Gripper](/tutorials/?tut=simple_gripper)
 
 This tutorial explains how to create a composite robot from existing robot parts, i.e. mobile base, simple arm and simple gripper.
 
@@ -14,7 +14,7 @@ Start up gazebo and make sure you can load the models from the two previous tuto
 
 ## Mobile Base
 
-1. Per instructions in [Make a Mobile Robot](http://gazebosim.org/tutorials/?tut=build_robot) tutorial, you should have a mobile base robot at your disposal:
+1. Per instructions in [Make a Mobile Robot](/tutorials/?tut=build_robot) tutorial, you should have a mobile base robot at your disposal:
 
     [[file:files/Mobile_base.png|640px]]
 

--- a/attach_meshes/tutorial.md
+++ b/attach_meshes/tutorial.md
@@ -1,6 +1,6 @@
 # Overview
 
-**Prerequisites:** [Make a mobile robot](http://gazebosim.org/tutorials/?tut=build_robot)
+**Prerequisites:** [Make a mobile robot](/tutorials/?tut=build_robot)
 
 Meshes can add realism to a model both visually and for sensors.  This tutorial demonstrates how the user can use custom meshes to define how their model will appear in simulation.
 
@@ -105,7 +105,7 @@ The most common use case for a mesh is to create a realistic looking visual.
 
 ##Further Reading##
 
-When creating a new robot, you'll likely want to use your own mesh file. The [import a mesh tutorial](http://gazebosim.org/tutorials/?tut=import_mesh) describes how to go about importing a mesh into a format suitable for Gazebo.
+When creating a new robot, you'll likely want to use your own mesh file. The [import a mesh tutorial](/tutorials/?tut=import_mesh) describes how to go about importing a mesh into a format suitable for Gazebo.
 
 ## Try for yourself ##
 
@@ -119,4 +119,4 @@ Note: Materials (texture files such with extension like .png or .jpg), should be
 
 ##Next##
 
-[Next: Add a Sensor to a Robot](http://gazebosim.org/tutorials/?tut=add_laser)
+[Next: Add a Sensor to a Robot](/tutorials/?tut=add_laser)

--- a/build_model/tutorial-7.md
+++ b/build_model/tutorial-7.md
@@ -74,4 +74,4 @@ Here is a good order in which to add features:
 1. Add all plugins (if any).
 
 With each new addition, load the model using the graphical client to make sure your model is correct.
-However, the `box.sdf` file alone isn't enough to be able to load the model into the graphical client. You must also setup your model directory correctly, which you will learn in the next tutorial: [Make a Mobile Robot](http://gazebosim.org/tutorials?tut=build_robot&cat=build_robot).
+However, the `box.sdf` file alone isn't enough to be able to load the model into the graphical client. You must also setup your model directory correctly, which you will learn in the next tutorial: [Make a Mobile Robot](/tutorials?tut=build_robot&cat=build_robot).

--- a/build_robot/tutorial.md
+++ b/build_robot/tutorial.md
@@ -4,7 +4,7 @@ The tutorial demonstrates Gazebo's basic model management, and exercises familia
 
 ## Setup your model directory ##
 
-Read through the [Model Database documentation](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot). You will be creating your own model, which must follow the formatting rules for the Gazebo Model Database directory structure.  Also, for details on model description formats, please refer to the [SDF reference](http://gazebosim.org/sdf).
+Read through the [Model Database documentation](/tutorials?tut=model_structure&cat=build_robot). You will be creating your own model, which must follow the formatting rules for the Gazebo Model Database directory structure.  Also, for details on model description formats, please refer to the [SDF reference](http://gazebosim.org/sdf).
 
 1.  Create a model directory:
 
@@ -110,7 +110,7 @@ It is important to start simple, and build up a model in steps. The first step i
     Here we have created a `box` with a size of `0.4 x 0.2 x 0.1` meters. The `collision` element specifies the shape used by the collision detection engine. The `visual` element specifies the shape used by the rendering engine. For most use cases the `collision` and `visual` elements are the same. The most common use for different `collision` and `visual` elements is to have a simplified `collision` element paired with a `visual` element that uses a complex mesh. This will help improve performance.
 
 1.  Try out your model by running gazebo, and importing your model through the
-    [Insert Model](http://gazebosim.org/tutorials?tut=build_world&cat=build_world#AddingModelfromtheModelDatabase)
+    [Insert Model](/tutorials?tut=build_world&cat=build_world#AddingModelfromtheModelDatabase)
     interface on the GUI.
 
         gazebo
@@ -520,4 +520,4 @@ It is important to start simple, and build up a model in steps. The first step i
     Idea: A six wheeled vehicle with a scoop front loading mechanism.
 
 ## Next ##
-[Next: Attach Meshes](http://gazebosim.org/tutorials/?tut=attach_meshes)
+[Next: Attach Meshes](/tutorials/?tut=attach_meshes)

--- a/build_world/tutorial.md
+++ b/build_world/tutorial.md
@@ -8,7 +8,7 @@ This tutorial describes the process of creating a world with both static and dyn
 
 # Setup
 
-1.  Make sure Gazebo is [installed](http://gazebosim.org/tutorials?cat=install).
+1.  Make sure Gazebo is [installed](/tutorials?cat=install).
 
 1.  Start up gazebo, and you should see a world with just a ground plane.
 
@@ -129,4 +129,4 @@ The filename must be in the current working directory, or you must specify the c
 
 # Next
 
-[Next: Modifying a world tutorial](http://gazebosim.org/tutorials/?tut=modifying_world)
+[Next: Modifying a world tutorial](/tutorials/?tut=modifying_world)

--- a/build_world/tutorial_1.9.md
+++ b/build_world/tutorial_1.9.md
@@ -8,7 +8,7 @@ This tutorial describes the process of creating a world with both static and dyn
 
 # Setup
 
-1.  Make sure Gazebo is [installed](http://gazebosim.org/tutorials?cat=install).
+1.  Make sure Gazebo is [installed](/tutorials?cat=install).
 
 1.  Create a working directory for this tutorial:
 
@@ -110,4 +110,4 @@ The filename must be in the current working directory, or you must specify the c
 
 # Next
 
-[Next: Modifying a world tutorial](http://gazebosim.org/tutorials/?tut=modifying_world)
+[Next: Modifying a world tutorial](/tutorials/?tut=modifying_world)

--- a/build_world/tutorial_2.2.md
+++ b/build_world/tutorial_2.2.md
@@ -8,7 +8,7 @@ This tutorial describes the process of creating a world with both static and dyn
 
 # Setup
 
-1.  Make sure Gazebo is [installed](http://gazebosim.org/tutorials?cat=install).
+1.  Make sure Gazebo is [installed](/tutorials?cat=install).
 
 1.  Start up gazebo, and you should see a world with just a ground plane.
 
@@ -115,4 +115,4 @@ The filename must be in the current working directory, or you must specify the c
 
 # Next
 
-[Next: Modifying a world tutorial](http://gazebosim.org/tutorials/?tut=modifying_world)
+[Next: Modifying a world tutorial](/tutorials/?tut=modifying_world)

--- a/building_editor/tutorial.md
+++ b/building_editor/tutorial.md
@@ -4,7 +4,7 @@ This tutorial describes the process of creating a building using the Building Ed
 
 ## Open the Building Editor
 
-1.  Make sure Gazebo is [installed](http://gazebosim.org/tutorials?cat=install).
+1.  Make sure Gazebo is [installed](/tutorials?cat=install).
 
 1.  Start up gazebo.
 
@@ -244,7 +244,7 @@ Colors and textures can be chosen from the Palette and assigned to items on your
 
 # Saving your building
 
-Saving will create a [directory, SDF and config files](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot) for your building.
+Saving will create a [directory, SDF and config files](/tutorials?tut=model_structure&cat=build_robot) for your building.
 
 Before saving, give your building a name on the Palette.
 

--- a/color_model/tutorial_7.md
+++ b/color_model/tutorial_7.md
@@ -159,7 +159,7 @@ See the [model structure tutorial](tutorials?tut=model_structure) for more infor
 
 [[file:files/model_files.png|256px]]
 
-The `models` folder itself must be in the environment variable [`GAZEBO_MODEL_PATH`](http://gazebosim.org/tutorials?tut=components#EnvironmentVariables).
+The `models` folder itself must be in the environment variable [`GAZEBO_MODEL_PATH`](/tutorials?tut=components#EnvironmentVariables).
 This tutorial will assume you use the folder `~/color_tutorial/models`.
 
 ```

--- a/components/tutorial.md
+++ b/components/tutorial.md
@@ -21,7 +21,7 @@ A model file uses the same [SDF](http://gazebosim.org/sdf.html) format as world 
 
 A number of models are provided in the [online model database](http://github.com/osrf/gazebo_models) (in previous versions, some example models were shipped with Gazebo).  Assuming that you have an Internet connection when running Gazebo, you can insert any model from the database and the necessary content will be downloaded at runtime.
 
-Read more about model files [here](http://gazebosim.org/tutorials?tut=build_model).
+Read more about model files [here](/tutorials?tut=build_model).
 
 # Environment Variables
 

--- a/contact_sensor/tutorial_4-0.md
+++ b/contact_sensor/tutorial_4-0.md
@@ -129,7 +129,7 @@ Between the `</contact>` and `</sensor>` tags in order to get output on the term
 
 It is also possible to create a plugin for the contact sensor. This plugin can get the collision data, manipulate it, and output it to an arbitrary destination (for example a ROS topic).
 
-*    **Note** This section of the tutorial requires you to compile a Gazebo plugin. For Gazebo version 3.0 and above, you will need to have the Gazebo dev packages installed (something like `libgazebo*-dev`). Check the [installation tutorials](http://gazebosim.org/tutorials?cat=install) for further instructions.
+*    **Note** This section of the tutorial requires you to compile a Gazebo plugin. For Gazebo version 3.0 and above, you will need to have the Gazebo dev packages installed (something like `libgazebo*-dev`). Check the [installation tutorials](/tutorials?cat=install) for further instructions.
 
 Start by modifying the `contact.world` SDF file. Add the following line directly below `<sensor name='my_contact' type='contact'>`:
 

--- a/contact_sensor/tutorial_7-0.md
+++ b/contact_sensor/tutorial_7-0.md
@@ -130,7 +130,7 @@ Between the `</contact>` and `</sensor>` tags in order to get output on the term
 
 It is also possible to create a plugin for the contact sensor. This plugin can get the collision data, manipulate it, and output it to an arbitrary destination (for example a ROS topic).
 
-*    **Note** This section of the tutorial requires you to compile a Gazebo plugin. For Gazebo version 3.0 and above, you will need to have the Gazebo dev packages installed (something like `libgazebo*-dev`). Check the [installation tutorials](http://gazebosim.org/tutorials?cat=install) for further instructions.
+*    **Note** This section of the tutorial requires you to compile a Gazebo plugin. For Gazebo version 3.0 and above, you will need to have the Gazebo dev packages installed (something like `libgazebo*-dev`). Check the [installation tutorials](/tutorials?cat=install) for further instructions.
 
 Start by modifying the `contact.world` SDF file. Add the following line directly below `<sensor name='my_contact' type='contact'>`:
 

--- a/drcsim_animate_joints/tutorial.md
+++ b/drcsim_animate_joints/tutorial.md
@@ -4,7 +4,7 @@ In this tutorial, we'll move a robot in simulation without dynamics through the 
 
 # Setup
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install&cat=drcsim).
 
 If you haven't done so, add the environment setup.sh files to your .bashrc.
 

--- a/drcsim_atlas_siminterface/tutorial.md
+++ b/drcsim_atlas_siminterface/tutorial.md
@@ -4,7 +4,7 @@ This tutorial describes how to use the Atlas Sim Interface to command Atlas to w
 
 ## Setup
 
-We assume that you've already done the [DRCSim installation step](http://gazebosim.org/tutorials?tut=drcsim_install).
+We assume that you've already done the [DRCSim installation step](/tutorials?tut=drcsim_install).
 
 If you haven't done so, make sure to source the environment setup.sh files with every new terminal you open:
 

--- a/drcsim_bdi_examples/tutorial.md
+++ b/drcsim_bdi_examples/tutorial.md
@@ -1,10 +1,10 @@
 # Overview
 
-This tutorial demonstrates how to start the 5-step behavior demo implemented in the Boston Dynamics Atlas Behavior Library.  Assuming DRCSim 2.7 or above was installed on your system, Atlas simulation behavior library documentations can be found locally, simply point your browser [here](https://bitbucket.org/osrf/drcsim/src/default/drcsim_model_resources/AtlasSimInterface_1.1.1/doc/html/?at=default). See also the [Keyboard teleop walking](http://gazebosim.org/tutorials/?tut=drcsim_keyboard_teleop) tutorial.
+This tutorial demonstrates how to start the 5-step behavior demo implemented in the Boston Dynamics Atlas Behavior Library.  Assuming DRCSim 2.7 or above was installed on your system, Atlas simulation behavior library documentations can be found locally, simply point your browser [here](https://bitbucket.org/osrf/drcsim/src/default/drcsim_model_resources/AtlasSimInterface_1.1.1/doc/html/?at=default). See also the [Keyboard teleop walking](/tutorials/?tut=drcsim_keyboard_teleop) tutorial.
 
 # Install DRC Simulator
 
-[Click to see the instructions](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities. This tutorial requires drcsim-2.7 or later.
+[Click to see the instructions](/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities. This tutorial requires drcsim-2.7 or later.
 
 # Launch the DRC Simulator
 

--- a/drcsim_create_atlas_world/tutorial.md
+++ b/drcsim_create_atlas_world/tutorial.md
@@ -2,7 +2,7 @@
 This tutorial will teach you how to create a Gazebo world and spawn Atlas into it.
 
 ## Setup
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install&cat=drcsim).
 
 If you haven't done so, add the environment setup.sh files to your .bashrc.
 

--- a/drcsim_fakewalking/tutorial.md
+++ b/drcsim_fakewalking/tutorial.md
@@ -4,7 +4,7 @@ This tutorial will explain how to drive simulated Atlas around as if it were a w
 
 ## Setup
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install).
 
 If you haven't done so, add the environment setup.sh files to your .bashrc.
 
@@ -15,7 +15,7 @@ source ~/.bashrc
 
 ## Background
 
-Note that this tutorial does not use the [walking controller](http://gazebosim.org/tutorials/?tut=drcsim_walking&cat=drcsim). It simply spawns Atlas with position controllers enabled that keep it standing upright, as shown in the following image:
+Note that this tutorial does not use the [walking controller](/tutorials/?tut=drcsim_walking&cat=drcsim). It simply spawns Atlas with position controllers enabled that keep it standing upright, as shown in the following image:
 
 [[file:files/Gazebo_with_drc_robot.png|640px]]
 

--- a/drcsim_grasp_sandia/tutorial.md
+++ b/drcsim_grasp_sandia/tutorial.md
@@ -4,7 +4,7 @@ In this tutorial, we'll send desired grasp pose to Sandia hands mounted on an At
 
 # Setup
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install&cat=drcsim).
 
 If you haven't done so, make sure to source the environment setup.sh files with every new terminal you open:
 

--- a/drcsim_install/tutorial.md
+++ b/drcsim_install/tutorial.md
@@ -84,7 +84,7 @@ There are several ways of getting a working gazebo installation to use with drcs
 1. Install using apt-get from the OSRF repository
 2. Install gazebo from source
 
-Both are very well documented in the [Gazebo Installation](http://gazebosim.org/tutorials?cat=install) page.
+Both are very well documented in the [Gazebo Installation](/tutorials?cat=install) page.
 
 ### Ubuntu and ROS Hydro
 

--- a/drcsim_launchfiles/tutorial.md
+++ b/drcsim_launchfiles/tutorial.md
@@ -6,7 +6,7 @@ If you have no prior experience with ROS launch files, you can learn more on the
 
 # Setup
 
-We assume that you've already installed DRCSim 4.2 or higher via the [installation instructions](http://gazebosim.org/tutorials/?tut=drcsim_install). If you have not installed a version of DRCSim greater than or equal to 4.2, you must upgrade before you can complete this tutorial.
+We assume that you've already installed DRCSim 4.2 or higher via the [installation instructions](/tutorials/?tut=drcsim_install). If you have not installed a version of DRCSim greater than or equal to 4.2, you must upgrade before you can complete this tutorial.
 
 If you haven't done so, add the environment setup.sh files to your .bashrc.
 
@@ -40,7 +40,7 @@ Boston Dynamics has released four versions of the Atlas robot: version 1, versio
 [[file:files/versions.png|750px]]
 
 ## Hands
-There are three hand models supported in DRCSim: the Sandia hand, the iRobot hand, and the RobotiQ hand. There are related tutorials for controlling the [Sandia](http://gazebosim.org/tutorials?tut=drcsim_grasp_sandia&cat=drcsim) hand and the [RobotiQ](http://gazebosim.org/tutorials?tut=drcsim_robotiq_hand&cat=drcsim) hand.
+There are three hand models supported in DRCSim: the Sandia hand, the iRobot hand, and the RobotiQ hand. There are related tutorials for controlling the [Sandia](/tutorials?tut=drcsim_grasp_sandia&cat=drcsim) hand and the [RobotiQ](/tutorials?tut=drcsim_robotiq_hand&cat=drcsim) hand.
 
 Sandia hands:
 

--- a/drcsim_modify_world/tutorial.md
+++ b/drcsim_modify_world/tutorial.md
@@ -9,7 +9,7 @@ This tutorial will explain how to modify the simulated Atlas's environment, such
 
 ## Setup ##
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install&cat=drcsim).
 
 If you haven't done so, add the environment setup.sh files to your .bashrc.
 
@@ -104,7 +104,7 @@ Now we need to change `atlas_no_controllers.launch` to refer to the correct worl
 
         <node name="gazebo" pkg="drcsim_gazebo" type="run_$(arg gzname)" args="$(find world_modification_tutorial)/worlds/$(arg gzworld) $(arg extra_gazebo_args)" output="screen" />
 
-Now you're ready to make modifications to the world.  There are a variety of ways to do this; see the [building a world](http://gazebosim.org/tutorials/?tut=drcsim_build_world) tutorial to get started. For now, we'll make some simple edits via the simulator GUI. Launch the Simulator using your just-edited `atlas.launch` file:
+Now you're ready to make modifications to the world.  There are a variety of ways to do this; see the [building a world](/tutorials/?tut=drcsim_build_world) tutorial to get started. For now, we'll make some simple edits via the simulator GUI. Launch the Simulator using your just-edited `atlas.launch` file:
 
     roslaunch world_modification_tutorial atlas.launch
 

--- a/drcsim_multisense/tutorial.md
+++ b/drcsim_multisense/tutorial.md
@@ -4,7 +4,7 @@ This tutorial introduces basic sensor stream visualization from simulated
 [MultiSense SL](http://files.carnegierobotics.com/products/MultiSense_SL/MultiSense_SL_brochure.pdf) sensor head using [rviz](http://ros.org/wiki/rviz).
 
 ## Setup
-If not done previously, [install DRCSim first](http://gazebosim.org/tutorials/?tut=drcsim_install).
+If not done previously, [install DRCSim first](/tutorials/?tut=drcsim_install).
 
 ## Starting Atlas Robot Simulation
 Source the environment setup script:
@@ -31,7 +31,7 @@ Next, start [rviz](http://ros.org/wiki/rviz)
     source /usr/share/drcsim/setup.sh
     rosrun rviz rviz
 
-and follow steps in [this tutorial](http://gazebosim.org/tutorials?tut=drcsim_visualization&cat=drcsim) to configure rviz properly.
+and follow steps in [this tutorial](/tutorials?tut=drcsim_visualization&cat=drcsim) to configure rviz properly.
 
 More importantly, repeat the steps to setup camera and laser visualization but substitute ROS topics in the original instructions with following ROS topics:
 

--- a/drcsim_robotiq_hand/tutorial.md
+++ b/drcsim_robotiq_hand/tutorial.md
@@ -5,7 +5,7 @@ as well as how to read its state and visualize it in rviz.
 
 # Setup
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install&cat=drcsim).
 
 If you haven't done so, make sure to source the environment setup.sh files with every new terminal you open:
 

--- a/drcsim_ros_cmds/tutorial.md
+++ b/drcsim_ros_cmds/tutorial.md
@@ -11,7 +11,7 @@ In particular, we will make use of two ROS topics in this tutorial:
 
 ## Setup
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install).
 
 If you haven't done so, make sure to source the environment setup.sh files with every new terminal you open:
 

--- a/drcsim_ros_python/tutorial.md
+++ b/drcsim_ros_python/tutorial.md
@@ -2,13 +2,13 @@
 
 This tutorial will demonstrate how to control the Atlas robot with a joint trajectory controller.  In the course of this tutorial we're going to make the Atlas robot try to take a step.  It will fall down, and that's OK, because our trajectory is incredibly simple and not at all reactive.  You're welcome to extend the example here to make the robot walk or go through other motions.
 
-We're using the ROS topics demonstrated in the [previous tutorial that used C++](http://gazebosim.org/tutorials/?tut=drcsim_ros_cmds&cat=drcsim).  This general-purpose controller can be used to make a set of joints follow a desired trajectory specified as joint angles.  The controller is executed as part of a Gazebo plugin.  This arrangement allows the controller to run in-line with the simulation, approximating the on-robot situation in which the controller runs in a real-time environment.
+We're using the ROS topics demonstrated in the [previous tutorial that used C++](/tutorials/?tut=drcsim_ros_cmds&cat=drcsim).  This general-purpose controller can be used to make a set of joints follow a desired trajectory specified as joint angles.  The controller is executed as part of a Gazebo plugin.  This arrangement allows the controller to run in-line with the simulation, approximating the on-robot situation in which the controller runs in a real-time environment.
 
 **Important note:** The approach to robot control described here is not the best or only way to control the Atlas robot. It is provided for demonstration purposes. DRC participants should be aware that we expect the control system in simulation to change substantially as more sophisticated controller become available.
 
 ## Install DRC Simulator
 
-[Click to see the instructions](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities.
+[Click to see the instructions](/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities.
 
 ## Create a new ROS package
 

--- a/drcsim_set_joint_damping/tutorial.md
+++ b/drcsim_set_joint_damping/tutorial.md
@@ -4,7 +4,7 @@ This tutorial will explain how to change Atlas robot and Sandia hand joint visco
 
 # Background
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim).
+We assume that you've already done the [installation step](/tutorials/?tut=drcsim_install&cat=drcsim).
 
 In this tutorial, we'll demonstrate how to call ROS services in command-line using [rosservice](http://www.ros.org/wiki/rosservice).
 

--- a/drcsim_vehicle/tutorial.md
+++ b/drcsim_vehicle/tutorial.md
@@ -4,7 +4,7 @@ This tutorial will demonstrate how to control the the DRC Vehicle using ROS topi
 
 ## Install DRC Simulator
 
-[Click to see the instructions](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities. This tutorial requires drcsim-3.1 or later.
+[Click to see the instructions](/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities. This tutorial requires drcsim-3.1 or later.
 
 ## Launch the DRC Simulator
 

--- a/drcsim_vehicle_atlas/tutorial.md
+++ b/drcsim_vehicle_atlas/tutorial.md
@@ -4,7 +4,7 @@ This tutorial will demonstrate how to automatically place the Atlas robot in the
 
 ## Install DRC Simulator
 
-[Click to see the instructions](http://gazebosim.org/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities.
+[Click to see the instructions](/tutorials/?tut=drcsim_install&cat=drcsim) for installing the DRC simulator and associated utilities.
 
 ## Launch the DRC Simulator
 
@@ -56,7 +56,7 @@ Please note that the VRC plugin uses a fixed joint to place Atlas in the car. If
 
 ## Test perception with Atlas in the vehicle
 
-With Atlas placed in the vehicle, you can use the methods described in [another tutorial](http://gazebosim.org/tutorials/?tut=drcsim_vehicle&cat=drcsim) to drive the vehicle using open-loop commands. This will allow testing of Atlas's perception systems while driving in the vehicle.
+With Atlas placed in the vehicle, you can use the methods described in [another tutorial](/tutorials/?tut=drcsim_vehicle&cat=drcsim) to drive the vehicle using open-loop commands. This will allow testing of Atlas's perception systems while driving in the vehicle.
 
 Disengage the hand brake:
 
@@ -76,7 +76,7 @@ Press the gas pedal:
 rostopic pub --once /drc_vehicle_xp900/gas_pedal/cmd std_msgs/Float64 '{ data : 1 }'
 ~~~
 
-Now the DRC Vehicle should be driving with Atlas in the passenger's seat. As described a [tutorial on using rviz](http://gazebosim.org/tutorials/?tut=drcsim_visualization&cat=drcsim) and a [tutorial on the MultiSense head](http://gazebosim.org/tutorials/?tut=drcsim_multisense&cat=drcsim), you can use rviz to view the camera or laser scan data while driving.
+Now the DRC Vehicle should be driving with Atlas in the passenger's seat. As described a [tutorial on using rviz](/tutorials/?tut=drcsim_visualization&cat=drcsim) and a [tutorial on the MultiSense head](/tutorials/?tut=drcsim_multisense&cat=drcsim), you can use rviz to view the camera or laser scan data while driving.
 
 ## Use Atlas robot's foot to press gas pedal
 

--- a/drcsim_visualization/tutorial.md
+++ b/drcsim_visualization/tutorial.md
@@ -6,7 +6,7 @@ See the documentation pages of [rviz](http://www.ros.org/wiki/rviz) and [rosbag]
 
 ## Setup
 
-We assume that you've already done the [installation step](http://gazebosim.org/tutorials?tut=drcsim_install&cat=drcsim).
+We assume that you've already done the [installation step](/tutorials?tut=drcsim_install&cat=drcsim).
 
 If you haven't done so, add the environment setup.sh files to your .bashrc.
 

--- a/elevators/tutorial.md
+++ b/elevators/tutorial.md
@@ -68,4 +68,4 @@ request takes place thanks to the Occupied Region Event, described next.
 
 # Occupied Region Event
 
-The elevator plugin works with the [OccupiedEvent](http://gazebosim.org/api/code/dev/classgazebo_1_1OccupiedEventSource.html) component of the [SimEventPlugin](http://gazebosim.org/api/code/dev/classgazebo_1_1SimEventsPlugin.html). The OccupiedEvent sends a message whenever a 3D region becomes occupied with a model. Refer to the [OccupiedEvent tutorial](http://gazebosim.org/tutorials?tut=occupiedevent&cat=plugins) for more information.
+The elevator plugin works with the [OccupiedEvent](http://gazebosim.org/api/code/dev/classgazebo_1_1OccupiedEventSource.html) component of the [SimEventPlugin](http://gazebosim.org/api/code/dev/classgazebo_1_1SimEventsPlugin.html). The OccupiedEvent sends a message whenever a 3D region becomes occupied with a model. Refer to the [OccupiedEvent tutorial](/tutorials?tut=occupiedevent&cat=plugins) for more information.

--- a/extrude_svg/tutorial.md
+++ b/extrude_svg/tutorial.md
@@ -5,7 +5,7 @@ This tutorial describes the process of extruding SVG files, which are 2D
  easier to design part of a model in a program like [Inkscape](https://inkscape.org/) or [Illustrator](www.adobe.com/Illustrator).
 
 Before starting, make sure you're familiar with the
- [Model Editor](http://gazebosim.org/tutorials?tut=model_editor).
+ [Model Editor](/tutorials?tut=model_editor).
 
 This tutorial will show you how to make a custom wheel as an .svg in Inkscape,
  and import it into Gazebo so that it can be attached to a robot.

--- a/fluids/tutorial.md
+++ b/fluids/tutorial.md
@@ -10,7 +10,7 @@ available the simulation will run in CPU mode).
 **Prerequisites:**
 
   * Nvidia graphics card
-  * Go through the basic Gazebo tutorials, especially through [world plugins](http://gazebosim.org/tutorials?tut=plugins_world), [system plugins](http://gazebosim.org/tutorials?tut=system_plugin), [transport library](http://gazebosim.org/tutorials?cat=transport) examples.
+  * Go through the basic Gazebo tutorials, especially through [world plugins](/tutorials?tut=plugins_world), [system plugins](/tutorials?tut=system_plugin), [transport library](/tutorials?cat=transport) examples.
  * For deeper understanding of the particle simulation look through some [Fluidix examples](http://onezero.ca/sample/?id=general_basic).
 
 # Install
@@ -32,7 +32,7 @@ available the simulation will run in CPU mode).
     sudo ./install.sh
     ~~~
 
-1. Install [gazebo](http://gazebosim.org/tutorials?cat=install) from source using the `fluid_sph` branch
+1. Install [gazebo](/tutorials?cat=install) from source using the `fluid_sph` branch
 
     ~~~
     [...]

--- a/ftu/tutorial3.md
+++ b/ftu/tutorial3.md
@@ -48,7 +48,7 @@ in the panel:
   
       This is an optional feature, so this tab will be empty in
       most cases. To learn more about Layers, check out the 
-      [Visibility Layers](http://gazebosim.org/tutorials?tut=visual_layers&cat=build_robot) 
+      [Visibility Layers](/tutorials?tut=visual_layers&cat=build_robot) 
       tutorial. 
 
 #### Right Panel (hidden by default)

--- a/gazebojs_install_mac/tutorial.md
+++ b/gazebojs_install_mac/tutorial.md
@@ -16,7 +16,7 @@ This page explains how to install the GazeboJs Node bindings to Gazebo.
 ### Mac OSX (using homebrew)
 
 This tutorial shows how to download, install and compile Gazebojs on a computer where Gazebo and its  development libraries are installed.
-Please refer to the [Install Gazebo on Mac (using homebrew)](http://gazebosim.org/tutorials?tut=install_on_mac&cat=install).
+Please refer to the [Install Gazebo on Mac (using homebrew)](/tutorials?tut=install_on_mac&cat=install).
 
 #### Setup
 

--- a/gravity_compensation/tutorial.md
+++ b/gravity_compensation/tutorial.md
@@ -1,12 +1,12 @@
 #Prerequisites
 
-[Plugins 101](http://gazebosim.org/tutorials?tut=plugins_hello_world) tutorial
+[Plugins 101](/tutorials?tut=plugins_hello_world) tutorial
 
-* This tutorial will use a [model plugin](http://gazebosim.org/tutorials?tut=plugins_model).
+* This tutorial will use a [model plugin](/tutorials?tut=plugins_model).
 
-[From source](http://gazebosim.org/tutorials?tut=install_from_source) tutorial
+[From source](/tutorials?tut=install_from_source) tutorial
 
-* Install optional [DART physics and utilities](http://gazebosim.org/tutorials?tut=install_from_source#OptionalPhysicsEngines) (`libdart6-utils-urdf-dev`).
+* Install optional [DART physics and utilities](/tutorials?tut=install_from_source#OptionalPhysicsEngines) (`libdart6-utils-urdf-dev`).
 
 # Overview
 

--- a/gui_overlay/tutorial9.md
+++ b/gui_overlay/tutorial9.md
@@ -15,7 +15,7 @@ Gazebo and receive data from Gazebo.
 
 The source code for this example is found [here](https://github.com/osrf/gazebo/blob/gazebo9/examples/plugins/gui_overlay_plugin_spawn).
 
-1. Install the latest Gazebo version: follow the [instructions of the install page](http://gazebosim.org/tutorials?cat=install)
+1. Install the latest Gazebo version: follow the [instructions of the install page](/tutorials?cat=install)
 
 1. Start by creating a working directory
 

--- a/guided_a/tutorial2.md
+++ b/guided_a/tutorial2.md
@@ -1,6 +1,6 @@
 # Run your own copy of Gazebo
 
-On the [previous tutorial](http://gazebosim.org/tutorials?tut=guided_a1)
+On the [previous tutorial](/tutorials?tut=guided_a1)
 we covered where to find the source code for Gazebo and other dependencies.
 
 This tutorial will go through the process of getting your own copy of the
@@ -99,7 +99,7 @@ Cool, now we have all the code, let's build our own copy of Gazebo!
 
 > **Note**: This tutorial goes over the most basic installation. If you need
 some special configuration, check out the full
-[install from source tutorial](http://gazebosim.org/tutorials?tut=install_from_source&cat=install).
+[install from source tutorial](/tutorials?tut=install_from_source&cat=install).
 
 1. Setup your computer to accept software from packages.osrfoundation.org.
 

--- a/guided_a/tutorial4.md
+++ b/guided_a/tutorial4.md
@@ -143,7 +143,7 @@ looks like:
         Total errors found: 0
 
 The tool does not catch all style errors. Be sure to take a look at Gazebo's
-[style guide](http://gazebosim.org/tutorials?tut=contrib_code&cat=development#Style)
+[style guide](/tutorials?tut=contrib_code&cat=development#Style)
 and follow all the directions contained there too.
 
 ## Documentation

--- a/guided_b/tutorial1.md
+++ b/guided_b/tutorial1.md
@@ -46,7 +46,7 @@ Gazebo is currently best used on [Ubuntu](http://www.ubuntu.com/download), a fla
 
 # Installation Instructions for Ubuntu #
 
-If you run into problems during the install, please see the [complete install instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install).
+If you run into problems during the install, please see the [complete install instructions](/tutorials?tut=install_ubuntu&cat=install).
 
 1. Download the installer. Right-clicking the [link to the installer](http://get.gazebosim.org) and choose 
 "Save Link As" to the Downloads directory of your disc.

--- a/guided_b/tutorial2.md
+++ b/guided_b/tutorial2.md
@@ -2,7 +2,7 @@
 
 This is an introduction to the Gazebo Graphical User Interface, or GUI. We will learn interface basics like what the buttons do and how to navigate in the scene. 
 
-By now, you should have Gazebo [installed](http://gazebosim.org/tutorials?cat=guided_b&tut=guided_b1&branch=ftu2). 
+By now, you should have Gazebo [installed](/tutorials?cat=guided_b&tut=guided_b1&branch=ftu2). 
 
 Start by opening Gazebo. Press Alt-F2, type Gazebo, and then press Enter. 
 
@@ -51,7 +51,7 @@ in the panel:
   
       This is an optional feature, so this tab will be empty in
       most cases. To learn more about Layers, check out the 
-      [Visibility Layers](http://gazebosim.org/tutorials?tut=visual_layers&cat=build_robot) 
+      [Visibility Layers](/tutorials?tut=visual_layers&cat=build_robot) 
       tutorial. 
 
 #### Right Panel (hidden by default)

--- a/guided_b/tutorial3.md
+++ b/guided_b/tutorial3.md
@@ -2,7 +2,7 @@
 
 Now we'll construct our simple robot. We'll make a wheeled vehicle and add a sensor that allows us to make the robot follow a blob (person).
 
-The Model Editor lets us construct simple models right in the Graphical User Interface (GUI). For more complex models, you'll need to learn how to write [SDF](http://sdformat.org/) files, and check out the tutorials on [building a robot](http://gazebosim.org/tutorials?cat=build_robot).
+The Model Editor lets us construct simple models right in the Graphical User Interface (GUI). For more complex models, you'll need to learn how to write [SDF](http://sdformat.org/) files, and check out the tutorials on [building a robot](/tutorials?cat=build_robot).
 But for now, we can do everything right in the Gazebo GUI!
 
 
@@ -39,7 +39,7 @@ The **Palette** has two tabs.
 
 #### Toolbar
 
-Like in Simulation mode, the main Toolbar in the Model Editor includes tools for interacting with the objects in the Scene (see the [User Interface](http://gazebosim.org/tutorials?cat=guided_b&tut=guided_b2) tutorial).
+Like in Simulation mode, the main Toolbar in the Model Editor includes tools for interacting with the objects in the Scene (see the [User Interface](/tutorials?cat=guided_b&tut=guided_b2) tutorial).
 
 The avaible tools are selection, translation, scaling, rotation, undo & redo, copy & paste, alignment, snapping, view adjustment, and joint creation.
 
@@ -207,7 +207,7 @@ The sensor we will add to the car is a depth camera sensor which is going to hel
 ### Adding a plugin
 
 The vehicle we have built so far is complete with all of the physical and sensor components. However, it will not really do much but stay still and generate depth data in simulation. Plugins are a great way to enhance the model with some autonomy by allowing it to perform computations such as sensor data
-   processing, path planning, and control. For simplicity, this tutorial will use an existing plugin for our vehicle. Note that it is possible to create your own plugins but it requires writing code. See the [Plugin tutorials](http://gazebosim.org/tutorials?cat=write_plugin).
+   processing, path planning, and control. For simplicity, this tutorial will use an existing plugin for our vehicle. Note that it is possible to create your own plugins but it requires writing code. See the [Plugin tutorials](/tutorials?cat=write_plugin).
 
 1. Go to the left panel and select the `Model` tab to see the parts that make up the car model you built.
 

--- a/guided_i/tutorial1.md
+++ b/guided_i/tutorial1.md
@@ -395,4 +395,4 @@ Now that we have a Velodyne LiDAR model, we can improve it in three ways:
 
 The first improvement will be addressed in the next tutorial.
 
-[Next Tutorial](http://gazebosim.org/tutorials?cat=guided_i&tut=guided_i2)
+[Next Tutorial](/tutorials?cat=guided_i&tut=guided_i2)

--- a/guided_i/tutorial2.md
+++ b/guided_i/tutorial2.md
@@ -98,7 +98,7 @@ In the next section, we will cover adding these meshes to the SDF model.
 
 Gazebo has defined a model directory structure that supports stand-alone
 models, and the ability to share models via an online model database. Review
-[this tutorial](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot) for more information.
+[this tutorial](/tutorials?tut=model_structure&cat=build_robot) for more information.
 
 Another benefit of Gazebo's model structure is that it conveniently
 organizes resources, such as mesh files, required by the model. In this
@@ -285,4 +285,4 @@ In the next tutorial we will add noise to the sensor reading. By default
 simulation will provide near-perfect data, and this does not match the data
 received in the real world.
 
-[Sensor Noise](http://gazebosim.org/tutorials?cat=guided_i&tut=guided_i3)
+[Sensor Noise](/tutorials?cat=guided_i&tut=guided_i3)

--- a/guided_i/tutorial3.md
+++ b/guided_i/tutorial3.md
@@ -15,7 +15,7 @@ of sensors. While Gaussian noise may not be very realistic, it is better
 than nothing and serves as a good first-pass approximation of noise.
 Gaussian noise is also relatively easy to apply to data streams.
 
-For more information on Gazebo's sensor noise model, visit [this tutorial](http://gazebosim.org/tutorials?tut=sensor_noise&cat=sensors).
+For more information on Gazebo's sensor noise model, visit [this tutorial](/tutorials?tut=sensor_noise&cat=sensors).
 
 ## Step 1: Visualize the sensor data
 
@@ -107,4 +107,4 @@ Gazebo's noise model can be accessed using the `<noise>` tag. See
 In the next section we will modify the Velodyne model so that it can be
 easily shared and reused.
 
-[Next Section](http://gazebosim.org/tutorials?cat=guided_i&tut=guided_i4)
+[Next Section](/tutorials?cat=guided_i&tut=guided_i4)

--- a/guided_i/tutorial4.md
+++ b/guided_i/tutorial4.md
@@ -16,7 +16,7 @@ people can use your model.
 You're welcome to go through the whole process described here, but since
 you'll be uploading an example model from the tutorial, your pull request
 will not be merged. See more details on
-[this](http://gazebosim.org/tutorials?tut=model_contrib)
+[this](/tutorials?tut=model_contrib)
 tutorial on how to contribute your original creations.
 
 1. Fork the `gazebo_models` database by visiting [https://github.com/osrf/gazebo_models/fork](https://github.com/osrf/gazebo_models/fork).
@@ -70,4 +70,4 @@ tutorial on how to contribute your original creations.
 The next tutorial in this series will add a plugin to the Velodyne sensor.
 This plugin will control the rotation of the sensor's upper portion.
 
-[Control plugin](http://gazebosim.org/tutorials?cat=guided_i&tut=guided_i5)
+[Control plugin](/tutorials?cat=guided_i&tut=guided_i5)

--- a/guided_i/tutorial5.md
+++ b/guided_i/tutorial5.md
@@ -14,7 +14,7 @@ tasks including moving objects, adding/removing objects, and accessing
 sensor data.
 
 More information on plugins is available in [these
-tutorials](http://gazebosim.org/tutorials?cat=write_plugin). It is highly
+tutorials](/tutorials?cat=write_plugin). It is highly
 recommended that you look over these tutorials before proceeding.
 
 # Install Gazebo headers
@@ -34,7 +34,7 @@ will include the plugin source code, and a CMake build script.
 
 We won't go into heavy detail about the various components of a plugin in
 order to keep this tutorial fairly short. Take a look at [these other
-tutorials](http://gazebosim.org/tutorials?cat=write_plugin) for more
+tutorials](/tutorials?cat=write_plugin) for more
 information.
 
 ## Step 1: Create a workspace
@@ -642,6 +642,6 @@ plugin.
 The final tutorial in this series discusses how to connect this plugin to
 ROS.
 
-[Connect to ROS](http://gazebosim.org/tutorials?cat=guided_i&tut=guided_i6)
+[Connect to ROS](/tutorials?cat=guided_i&tut=guided_i6)
 
 

--- a/gzweb_install/tutorial.md
+++ b/gzweb_install/tutorial.md
@@ -121,7 +121,7 @@ Running GzWeb involves the following pieces:
   http://127.0.0.1:11345)
 
 * GzWeb's NodeJS server which communicates with `gzserver` using
-  [Gazebo Transport](http://gazebosim.org/tutorials?tut=topics_subscribed&cat=transport).
+  [Gazebo Transport](/tutorials?tut=topics_subscribed&cat=transport).
   It works as a bridge between the Javascript and the C++ code.
 
 * An HTTP server which serves static content such as models and website assets

--- a/gzweb_install/tutorial_1.9.md
+++ b/gzweb_install/tutorial_1.9.md
@@ -5,7 +5,7 @@ Gzweb is installed on the server-side. Once the server is set up and running, cl
 # Dependencies
 
 Gzweb is a graphical interface which communicates with gzserver. To use
- gzserver, install either [Gazebo](http://gazebosim.org/install) or [DRCSim](http://gazebosim.org/tutorials?tut=drcsim_install&cat=drcsim).
+ gzserver, install either [Gazebo](http://gazebosim.org/install) or [DRCSim](/tutorials?tut=drcsim_install&cat=drcsim).
 
  1. Make sure your system has the right NodeJS version (0.10.x). While this is
  not the latest version, it is the version that ships with Ubuntu Trusty.
@@ -160,7 +160,7 @@ Gzweb is a graphical interface which communicates with gzserver. To use
 
  * **Q: When running `./deploy.sh`, it is missing a file in `gz3d/build`:**
 
-    A: You will need to install Grunt and run it appropriately, as described in the [development](http://gazebosim.org/tutorials?tut=gzweb_development) section.
+    A: You will need to install Grunt and run it appropriately, as described in the [development](/tutorials?tut=gzweb_development) section.
 
  * **Q: When running `./deploy.sh`, I see errors along the lines of:**
 

--- a/gzweb_install/tutorial_7.md
+++ b/gzweb_install/tutorial_7.md
@@ -109,7 +109,7 @@ Running GzWeb involves the following pieces:
   http://127.0.0.1:11345)
 
 * GzWeb's NodeJS server which communicates with `gzserver` using
-  [Gazebo Transport](http://gazebosim.org/tutorials?tut=topics_subscribed&cat=transport).
+  [Gazebo Transport](/tutorials?tut=topics_subscribed&cat=transport).
   It works as a bridge between the Javascript and the C++ code.
 
 * An HTTP server which serves static content such as models and website assets

--- a/haptix_comm/tutorial.md
+++ b/haptix_comm/tutorial.md
@@ -5,7 +5,7 @@
 This tutorial will explain how to use the C HAPTIX client library `haptix-comm` for
 requesting a description of the hand, sending new joint commands, and receiving state updates.
 
-We assume that you have already done the [installation step](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix).
+We assume that you have already done the [installation step](/tutorials?tut=haptix_install&cat=haptix).
 
 
 # Compile your controller

--- a/haptix_install/tutorial.md
+++ b/haptix_install/tutorial.md
@@ -60,7 +60,7 @@ Download the SDK by going to:
 * [Windows Client SDK Download](http://gazebosim.org/distributions/haptix)
 
 and selecting a version.  You probably want the latest version that is
-available (but check below for information on [version compatibility section near the bottom of this document](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix#Versioncompatiblity)).
+available (but check below for information on [version compatibility section near the bottom of this document](/tutorials?tut=haptix_install&cat=haptix#Versioncompatiblity)).
 
 Unzip the zip file into your preferred HAPTIX folder. For example: `C:\Users\osrf\Desktop\haptix-ws`.
 

--- a/haptix_logging/tutorial.md
+++ b/haptix_logging/tutorial.md
@@ -5,7 +5,7 @@ saving your simulation episode on disk and being able to reproduce it
 afterwards.
 
 We assume that you have already done the
-[installation step](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix)
+[installation step](/tutorials?tut=haptix_install&cat=haptix)
 and you are also familiar with the HAPTIX API.
 
 # A Gazebo log file
@@ -38,7 +38,7 @@ subdirectory and a `state.log` file. Here is an example:
 # Enable Gazebo logging from your C++ program
 
 Follow the steps described in the
-[HAPTIX C-API tutorial](http://gazebosim.org/tutorials?cat=haptix&tut=haptix_comm)
+[HAPTIX C-API tutorial](/tutorials?cat=haptix&tut=haptix_comm)
 for compiling a program using your favorite operating system.
 
 Uncomment the following blocks to enable logging:
@@ -63,7 +63,7 @@ When executed, this example should create a `/tmp/log/` directory containing a
 # Enable Gazebo logging from your MATLAB/Octave program
 
 Follow the
-[HAPTIX Matlab and Octave API tutorial](http://gazebosim.org/tutorials?cat=haptix&tut=haptix_matlab)
+[HAPTIX Matlab and Octave API tutorial](/tutorials?cat=haptix&tut=haptix_matlab)
 and load the `hx_matlab_controller` in Octave or MATLAB.
 
 Uncomment the following blocks to enable logging:

--- a/haptix_luke_hand/tutorial.md
+++ b/haptix_luke_hand/tutorial.md
@@ -3,7 +3,7 @@ This tutorial describes how to install the DEKA Luke hand model and how to start
 the simulation environment with this limb.
 
 We assume that you have already completed the
-[installation step](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix).
+[installation step](/tutorials?tut=haptix_install&cat=haptix).
 
 ## Getting the DEKA Luke hand model and documentation
 

--- a/haptix_matlab/tutorial.md
+++ b/haptix_matlab/tutorial.md
@@ -4,7 +4,7 @@ This tutorial will explain how to use Matlab in Windows or Octave in Linux for r
 description of the hand, sending new joint commands, and receiving state updates. The Matlab
 and Octave systems have the same API, but the steps to run each system differ slightly.
 
-We assume that you have already done the [installation step](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix).
+We assume that you have already done the [installation step](/tutorials?tut=haptix_install&cat=haptix).
 
 # Start the Gazebo simulation
 

--- a/haptix_optitrack/tutorial.md
+++ b/haptix_optitrack/tutorial.md
@@ -4,7 +4,7 @@ This tutorial describes how to configure the Optitrack motion tracking system fo
 ## What you'll need
 All of the necessary items, including all software components, will be provided to participating HAPTIX teams. We are also providing links for any participants or hobbyists who want to create their own kit.
 
-1. A Linux computer with the HAPTIX Gazebo simulator installed (see [here](http://gazebosim.org/tutorials?cat=haptix&tut=haptix_install) for instructions).
+1. A Linux computer with the HAPTIX Gazebo simulator installed (see [here](/tutorials?cat=haptix&tut=haptix_install) for instructions).
 
 1. A Windows computer or a Windows virtual machine (VM) with the Motive motion tracking software installed. HAPTIX team machines come pre-installed with a Windows VM that initializes on startup. (Motive software installation instructions are [here](https://www.naturalpoint.com/optitrack/downloads/motive.html)).
 

--- a/haptix_scoring_plugin/tutorial.md
+++ b/haptix_scoring_plugin/tutorial.md
@@ -7,9 +7,9 @@ manipulation dexterity testing inspired by a paper titled
 written by Valero-Cuevas et. al. in 2003.
 
 For this tutorial, we assume that you have already completed the
-[HAPTIX handsim installation step](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix)
+[HAPTIX handsim installation step](/tutorials?tut=haptix_install&cat=haptix)
 and we strongly recommend that you have completed the
-[simulation world API tutorials](http://gazebosim.org/tutorials?tut=haptix_sim_api&cat=haptix).
+[simulation world API tutorials](/tutorials?tut=haptix_sim_api&cat=haptix).
 
 # Running the Simulation Example
 
@@ -19,7 +19,7 @@ To start Gazebo handsim scoring plugin example, run gazebo in terminal:
 gazebo --verbose worlds/luke_hand.world
 ~~~
 
-By default it brings up the desktop world with the [Luke Hand model](http://gazebosim.org/tutorials?tut=haptix_luke_hand&cat=haptix).
+By default it brings up the desktop world with the [Luke Hand model](/tutorials?tut=haptix_luke_hand&cat=haptix).
 
 Integrated in this world is a spring compression test that uses
 the SimEventsPlugin to keep track of the status of aforementioned task completion.
@@ -154,7 +154,7 @@ In the [luke_hand.world](https://bitbucket.org/osrf/handsim/src/8fe03d4d113659c1
     </plugin>
 ~~~
 
-(For reference, [here are the documentation for SDF format](http://www.sdformat.org/) and here are [some basic tutorials on using SDF to build simulation worlds and models](http://gazebosim.org/tutorials?cat=build_world)).
+(For reference, [here are the documentation for SDF format](http://www.sdformat.org/) and here are [some basic tutorials on using SDF to build simulation worlds and models](/tutorials?cat=build_world)).
 
 And the accompanying source code blocks that interprets the results of the `SimEventsPlugin` data can be found in
 [HaptixGUIPlugin.cc](https://bitbucket.org/osrf/handsim/src/default/src/HaptixGUIPlugin.cc).

--- a/haptix_sim_api/tutorial.md
+++ b/haptix_sim_api/tutorial.md
@@ -2,7 +2,7 @@
 This tutorial gives an overview of the haptix-comm simulation-specific API.
 
 We assume that you have already completed the
-[installation step](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix).
+[installation step](/tutorials?tut=haptix_install&cat=haptix).
 
 # Documentation
 The full world API documentation can be found
@@ -219,8 +219,8 @@ to drop through the table. We then set it back to the original collide mode.
 You can also specify a new name for the model and an initial position and orientation.
 
 To learn how to create a model in SDF, refer to the
-[Gazebo model building tutorials](http://gazebosim.org/tutorials?cat=build_robot)
-or learn how to use the [model editor](http://gazebosim.org/tutorials?cat=model_editor_top).
+[Gazebo model building tutorials](/tutorials?cat=build_robot)
+or learn how to use the [model editor](/tutorials?cat=model_editor_top).
 
 `hxs_remove_model` removes the model with the matching name from the world. Note that
 `hxs_remove_model` will return an error if it tries to remove a model that does
@@ -242,7 +242,7 @@ based on the scalar inputs.
 In this example, we try to set the state of the robotic arm's wrist joint.
 The joint will snap back to its original position because the motors in the arm
 are actively controlling the joints. To properly set the wrist joint, use `hx_update`
-(described in [another tutorial](http://gazebosim.org/tutorials?tut=haptix_matlab&cat=haptix)).
+(described in [another tutorial](/tutorials?tut=haptix_matlab&cat=haptix)).
 
 ### `hxs_reset`
 Reset the world. If argument "0" is passed to reset, the robotic arm and the viewpoint

--- a/haptix_tactors/tutorial.md
+++ b/haptix_tactors/tutorial.md
@@ -16,7 +16,7 @@ Hardware
 
 Software
 --------
-You will need a Linux machine with Gazebo and the handsim package. See [this tutorial](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix) for installation instructions.
+You will need a Linux machine with Gazebo and the handsim package. See [this tutorial](/tutorials?tut=haptix_install&cat=haptix) for installation instructions.
 
 To program the Teensy USB board, you will need to install the [Arduino IDE](http://arduino.cc/en/Main/Software) and the [Teensyduino add-on](https://www.pjrc.com/teensy/teensyduino.html) for Arduino.
 

--- a/haptix_teleop/tutorial.md
+++ b/haptix_teleop/tutorial.md
@@ -102,7 +102,7 @@ sudo spacenavd
 
 ## Razer Hydra
 
-Please follow the [hydra installation instructions](http://gazebosim.org/tutorials?tut=hydra&cat=user_input).
+Please follow the [hydra installation instructions](/tutorials?tut=hydra&cat=user_input).
 
 Once installed, the right paddle will perform the following actions:
 

--- a/haptix_unboxing/tutorial.md
+++ b/haptix_unboxing/tutorial.md
@@ -1,7 +1,7 @@
 # Overview
 This document provides instructions for replicating the setup used by participating HAPTIX teams.
 
-Please note that you can install the full simulation environment on a standalone Linux machine by simply following the [installation tutorial](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix). This tutorial is for users who want to integrate 3D vision and motion capture for a full virtual reality experience.
+Please note that you can install the full simulation environment on a standalone Linux machine by simply following the [installation tutorial](/tutorials?tut=haptix_install&cat=haptix). This tutorial is for users who want to integrate 3D vision and motion capture for a full virtual reality experience.
 
 # Inventory
 
@@ -182,9 +182,9 @@ You will need to restart your computer for the new drivers to take effect.
 
 1. Put the glasses on. The Gazebo window should look 3D.
 
-1. You can use the keyboard to move the arm and the mouse to change the viewpoint. Or, you can use the Spacenav to control the arm and viewpoint position. Press the button on the Spacenav to toggle between arm and viewpoint. The number keys (1-5) will control pre-defined grasps (see the [teleop tutorial](http://gazebosim.org/tutorials?cat=haptix&tut=haptix_teleop) for more information).
+1. You can use the keyboard to move the arm and the mouse to change the viewpoint. Or, you can use the Spacenav to control the arm and viewpoint position. Press the button on the Spacenav to toggle between arm and viewpoint. The number keys (1-5) will control pre-defined grasps (see the [teleop tutorial](/tutorials?cat=haptix&tut=haptix_teleop) for more information).
 
-1. Move to the [next tutorial](http://gazebosim.org/tutorials?cat=haptix&tut=haptix_optitrack) for instructions on configuring the OptiTrack 3D camera for viewpoint and arm pose control.
+1. Move to the [next tutorial](/tutorials?cat=haptix&tut=haptix_optitrack) for instructions on configuring the OptiTrack 3D camera for viewpoint and arm pose control.
 
 # Troubleshooting
 

--- a/haptix_world_sim_api/tutorial.md
+++ b/haptix_world_sim_api/tutorial.md
@@ -4,16 +4,16 @@ It also provides a simple example on how to sense object interactions
 and manipulate object color using the simulation world API.
 
 We assume that you have already completed the
-[installation step](http://gazebosim.org/tutorials?tut=haptix_install&cat=haptix)
+[installation step](/tutorials?tut=haptix_install&cat=haptix)
 and the
-[world API](http://gazebosim.org/tutorials?tut=haptix_sim_api&cat=haptix)
+[world API](/tutorials?tut=haptix_sim_api&cat=haptix)
 tutorials.
 
 # Documentation
 The full world API documentation can be found
 [here](https://s3.amazonaws.com/osrf-distributions/haptix/api/0.7.1/haptix__sim_8h.html).
 
-The documentation for building a Gazebo world using [SDF format](http://www.sdformat.org/) can be found [here](http://gazebosim.org/tutorials?cat=build_world).
+The documentation for building a Gazebo world using [SDF format](http://www.sdformat.org/) can be found [here](/tutorials?cat=build_world).
 
 # Matlab Example
 
@@ -79,7 +79,7 @@ it comes into contact with other objects:
 
 <include lang='c' src='https://github.com/osrf/gazebo_tutorials/raw/master/haptix_world_sim_api/files/custom_world.c'/>
 
-Build `custom_world.c` as you would with any Haptix C API code as shown in [Compile section under the Haptix C API tutorial](http://gazebosim.org/tutorials?tut=haptix_comm&cat=haptix#Compileyourcontroller).
+Build `custom_world.c` as you would with any Haptix C API code as shown in [Compile section under the Haptix C API tutorial](/tutorials?tut=haptix_comm&cat=haptix#Compileyourcontroller).
 
 ## Get the code:
 
@@ -99,7 +99,7 @@ gazebo custom_haptix.world
 
 ## Run the code: MATLAB, Octave on Linux
 
-First see [world API tutorial Example section](http://gazebosim.org/tutorials?tut=haptix_sim_api&cat=haptix#Example) on how to run Matlab or Octave scripts.
+First see [world API tutorial Example section](/tutorials?tut=haptix_sim_api&cat=haptix#Example) on how to run Matlab or Octave scripts.
 
 Next, invoke the `custom_world.m` script in Matlab or Octave command prompt
 and the sphere should change color from green to red as the hand passes through it:
@@ -115,7 +115,7 @@ before running `custom_world.m`.
 
 ## Run the code: Using C-API on Linux
 
-Run compiled binary from `custom_world.c` as you would with any Haptix C API code as shown in [Running the simulation section under the Haptix C API tutorial](http://gazebosim.org/tutorials?tut=haptix_comm&cat=haptix#Runningthesimulationwithyourcontroller).
+Run compiled binary from `custom_world.c` as you would with any Haptix C API code as shown in [Running the simulation section under the Haptix C API tutorial](/tutorials?tut=haptix_comm&cat=haptix#Runningthesimulationwithyourcontroller).
 
 ## Example Video
 <iframe width="600" height="450" src="https://www.youtube.com/embed/bWaWNZu-0n4" frameborder="0" allowfullscreen></iframe>

--- a/hydrodynamics/tutorial.md
+++ b/hydrodynamics/tutorial.md
@@ -5,7 +5,7 @@ This tutorial describes how to use the [BuoyancyPlugin](http://gazebosim.org/api
 
 # Prerequisites
 See [this
-tutorial](http://gazebosim.org/tutorials?tut=aerodynamics&cat=physics)
+tutorial](/tutorials?tut=aerodynamics&cat=physics)
 for an overview of the [LiftDragPlugin](http://gazebosim.org/api/code/dev/classgazebo_1_1LiftDragPlugin.html).
 
 # Background

--- a/inertia/tutorial.md
+++ b/inertia/tutorial.md
@@ -244,7 +244,7 @@ the text output.
 # Filling in the tags in URDF or [SDF](http://sdformat.org)
 
 The next step is to record the computed values to the URDF or [SDF](http://sdformat.org) file containing your robot (it is assumed you already have the robot model; if not, follow the tutorial
-[Make a Model](http://gazebosim.org/tutorials?tut=build_model&cat=build_robot)).
+[Make a Model](/tutorials?tut=build_model&cat=build_robot)).
 
 In each link you should have the `<inertial>` tag.
 It should look like the following (in [SDF](http://sdformat.org)):

--- a/install_from_source/tutorial_8.md
+++ b/install_from_source/tutorial_8.md
@@ -110,7 +110,7 @@ ask for guidance at [Gazebo Answers](https://answers.gazebosim.org), explaining
 your specific use case.
 
 To build these libraries from source, first go through the
-[Build dependencies from source](http://gazebosim.org/tutorials?tut=install_dependencies_from_source)
+[Build dependencies from source](/tutorials?tut=install_dependencies_from_source)
 tutorial and then come back here.
 
 ### Build And Install Gazebo
@@ -198,7 +198,7 @@ If Gazebo was installed to `/usr/local/` and running gazebo throws an error simi
     sudo ldconfig
 
 1. If you are interested in using Gazebo with [ROS](http://www.ros.org),
-see [Installing gazebo\_ros\_pkgs](http://gazebosim.org/tutorials?cat=connect_ros).
+see [Installing gazebo\_ros\_pkgs](/tutorials?cat=connect_ros).
 
 #### Install in a catkin workspace
 

--- a/install_from_source/tutorial_default.md
+++ b/install_from_source/tutorial_default.md
@@ -108,7 +108,7 @@ ask for guidance at [Gazebo Answers](https://answers.gazebosim.org), explaining
 your specific use case.
 
 To build these libraries from source, first go through the
-[Build dependencies from source](http://gazebosim.org/tutorials?tut=install_dependencies_from_source)
+[Build dependencies from source](/tutorials?tut=install_dependencies_from_source)
 tutorial and then come back here.
 
 ### Build And Install Gazebo
@@ -196,7 +196,7 @@ If Gazebo was installed to `/usr/local/` and running gazebo throws an error simi
     sudo ldconfig
 
 1. If you are interested in using Gazebo with [ROS](http://www.ros.org),
-see [Installing gazebo\_ros\_pkgs](http://gazebosim.org/tutorials?cat=connect_ros).
+see [Installing gazebo\_ros\_pkgs](/tutorials?cat=connect_ros).
 
 #### Install in a catkin workspace
 

--- a/install_from_source/tutorial_old.md
+++ b/install_from_source/tutorial_old.md
@@ -205,7 +205,7 @@ If Gazebo was installed to `/usr/local/` and running gazebo throws an error simi
     sudo ldconfig
 
 1. If you are interested in using Gazebo with [ROS](http://www.ros.org),
-see [Installing gazebo\_ros\_pkgs](http://gazebosim.org/tutorials?cat=connect_ros).
+see [Installing gazebo\_ros\_pkgs](/tutorials?cat=connect_ros).
 
 #### Install in a catkin workspace
 

--- a/install_other_linux/tutorial-9.0.md
+++ b/install_other_linux/tutorial-9.0.md
@@ -1,7 +1,7 @@
 # Install Gazebo on Linux distributions (non Ubuntu)
 
 Gazebo is available to install on other Linux distributions different than Ubuntu
-([Ubuntu install instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install)
+([Ubuntu install instructions](/tutorials?tut=install_ubuntu&cat=install)
 are hosted in a different tutorial). Linux distributions providing gazebo packages:
 Debian, Fedora, Arch and Gentoo.
 

--- a/install_other_linux/tutorial.md
+++ b/install_other_linux/tutorial.md
@@ -1,7 +1,7 @@
 # Install Gazebo on Linux distributions (non Ubuntu)
 
 Gazebo is available to install on other Linux distributions different than Ubuntu
-([Ubuntu install instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install)
+([Ubuntu install instructions](/tutorials?tut=install_ubuntu&cat=install)
 are hosted in a different tutorial). Linux distributions providing gazebo packages:
 Debian, Fedora, Arch and Gentoo.
 

--- a/install_ubuntu/tutorial_11.0.md
+++ b/install_ubuntu/tutorial_11.0.md
@@ -19,7 +19,7 @@ Some notes:
     software versions so from-source installations will also be an option.
 
   * If you are a [ROS](http://ros.org) user, please read the tutorial about the
-    [ROS/Gazebo installation](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connect_ros).
+    [ROS/Gazebo installation](/tutorials?tut=ros_wrapper_versions&cat=connect_ros).
 
 ## Default installation: one-liner
 

--- a/install_ubuntu/tutorial_9-0.md
+++ b/install_ubuntu/tutorial_9-0.md
@@ -8,7 +8,7 @@ Gazebo is also released as an Ubuntu official package: ([check which
 version](https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=gazebo&searchon=sourcenames)
 is available for every distribution. If you are a [ROS](http://ros.org) user, please
 read the tutorial about [ROS/Gazebo
-installation](http://gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connect_ros).
+installation](/tutorials?tut=ros_wrapper_versions&cat=connect_ros).
 
 ## Default installation: one-liner
 

--- a/instrument_hdf5_datasets/tutorial.md
+++ b/instrument_hdf5_datasets/tutorial.md
@@ -18,7 +18,7 @@ sudo apt-get install libhdf5-dev
 ## Build Gazebo
 This HDF5 instrument tool requires building Gazebo from source, with the cmake parameter
 `HDF5_INSTRUMENT` [default False] as True.
-[Learn how to build Gazebo from source](http://gazebosim.org/tutorials?tut=install_from_source&cat=install)
+[Learn how to build Gazebo from source](/tutorials?tut=install_from_source&cat=install)
 
     cd ~/gazebo
     mkdir build

--- a/kinematic_loop/tutorial.md
+++ b/kinematic_loop/tutorial.md
@@ -29,7 +29,7 @@ and
 [model.sdf](https://github.com/osrf/gazebo_tutorials/raw/master/kinematic_loop/four_bar_sdf/model.sdf)
 to that folder.
 You can then insert the model into a simulation using the `Insert` panel
-in the [left side of the gazebo client](http://gazebosim.org/tutorials?cat=guided_b&tut=guided_b2).
+in the [left side of the gazebo client](/tutorials?cat=guided_b&tut=guided_b2).
 
 For brevity, the model parameters are encoded in an embedded ruby template file named
 [model.sdf.erb](https://github.com/osrf/gazebo_tutorials/raw/master/kinematic_loop/four_bar_sdf/model.sdf.erb).

--- a/log_filtering/tutorial_4-0.md
+++ b/log_filtering/tutorial_4-0.md
@@ -21,7 +21,7 @@ gz log -h
 # Example Usage
 
 > **Tip**: Check out the
-[tutorial](http://gazebosim.org/tutorials?tut=logging_playback)
+[tutorial](/tutorials?tut=logging_playback)
 on logging and playback for an overview of ways to record a log.
 
 ## Step 1: Create a state log file

--- a/logging_playback/tutorial.md
+++ b/logging_playback/tutorial.md
@@ -141,7 +141,7 @@ Samples might be any number of iterations and seconds apart.
 
 As mentioned above, the `gz log` tool provides several options for introspecting
 your log file. Check out
-[this](http://gazebosim.org/tutorials?tut=log_filtering&cat=tools_utilities)
+[this](/tutorials?tut=log_filtering&cat=tools_utilities)
 tutorial for log filtering, for example.
 
 Here, let's quickly go over how you would take a look at the recorded states.

--- a/logical_camera_sensor/tutorial_7+.md
+++ b/logical_camera_sensor/tutorial_7+.md
@@ -113,7 +113,7 @@ Both ways return a [LogicalCameraImage](https://github.com/osrf/gazebo/blob/gaze
 
 ## Directly From The Sensor
 The data can be taken directly from the sensor.
-You will need to write a [gazebo plugin](http://gazebosim.org/tutorials?tut=plugins_hello_world&cat=write_plugin) to access it.
+You will need to write a [gazebo plugin](/tutorials?tut=plugins_hello_world&cat=write_plugin) to access it.
 Only the most recently generated message is available.
 
 1. Get a generic sensor pointer using the name of the sensor.

--- a/model_contrib/tutorial.md
+++ b/model_contrib/tutorial.md
@@ -3,7 +3,7 @@
 This tutorial will explain how to add a model to the
 [Gazebo Model Database](http://models.gazebosim.org/).
 You can read more about the database
-[here](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot).
+[here](/tutorials?tut=model_structure&cat=build_robot).
 
 This tutorial assumes you have created an original Gazebo model and you'd like
 to share it with the community.

--- a/model_editor/tutorial.md
+++ b/model_editor/tutorial.md
@@ -1,7 +1,7 @@
 # Overview
 
 This tutorial describes the process of creating a model using the Model Editor.
-See [this tutorial](http://gazebosim.org/tutorials?tut=guided_b3) for a walkthrough
+See [this tutorial](/tutorials?tut=guided_b3) for a walkthrough
 of creating a simple mobile base with the model editor.
 
 ## Open the Model Editor
@@ -141,7 +141,7 @@ As an example, try changing the joint pose and joint type. Once you are done, cl
 
 # Saving your model
 
-Saving will create a [directory, SDF and config files](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot) for your model.
+Saving will create a [directory, SDF and config files](/tutorials?tut=model_structure&cat=build_robot) for your model.
 
 As an exercise, let's build a simple car and save it. The car will have a
 box chassis and four cylinder wheels. Each wheel will be connected to the

--- a/model_editor/tutorial_6.md
+++ b/model_editor/tutorial_6.md
@@ -136,7 +136,7 @@ to see the changes reflected in the 3D view. Once you are done, click on
 
 # Saving your model
 
-Saving will create a [directory, SDF and config files](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot) for your model.
+Saving will create a [directory, SDF and config files](/tutorials?tut=model_structure&cat=build_robot) for your model.
 
 As an exercise, let's build a simple car and save it. The car will have a
 box chassis and four cylinder wheels. Each wheel will be connected to the

--- a/model_editor/tutorial_7.md
+++ b/model_editor/tutorial_7.md
@@ -138,7 +138,7 @@ As an example, try changing the joint pose and joint type. Once you are done, cl
 
 # Saving your model
 
-Saving will create a [directory, SDF and config files](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot) for your model.
+Saving will create a [directory, SDF and config files](/tutorials?tut=model_structure&cat=build_robot) for your model.
 
 As an exercise, let's build a simple car and save it. The car will have a
 box chassis and four cylinder wheels. Each wheel will be connected to the

--- a/modifying_world/tutorial.md
+++ b/modifying_world/tutorial.md
@@ -44,4 +44,4 @@ See the [sdf physics documentation](http://osrf-distributions.s3.amazonaws.com/s
 
 # Next
 
-[Next: How to use DEMs in Gazebo](http://gazebosim.org/tutorials/?tut=dem)
+[Next: How to use DEMs in Gazebo](/tutorials/?tut=dem)

--- a/nested_model/tutorial.md
+++ b/nested_model/tutorial.md
@@ -1,6 +1,6 @@
 # Overview
 
-**Prerequisites:** [Make a model](http://gazebosim.org/tutorials/?tut=build_model)
+**Prerequisites:** [Make a model](/tutorials/?tut=build_model)
 
 This tutorial describes how you can embed a model inside another to create an
 assembly of models.
@@ -8,7 +8,7 @@ assembly of models.
 # Nested Model
 
 It was seen in the
-[Make a model](http://gazebosim.org/tutorials/?tut=build_model) tutorial that a
+[Make a model](/tutorials/?tut=build_model) tutorial that a
 model SDF is composed of a collection of `links` and `joints`. As of SDF 1.5,
 the `<model>` SDF element has been extended to support self-referencing, which
 means allowing `<model>` elements to be nested. Support for loading nested
@@ -99,7 +99,7 @@ nested model links need to be scoped but minus the top level model name prefix.
 # Note on the include SDF element
 
 Another approach for nesting models is demonstrated in the
-[Add a Sensor to a Robot](http://gazebosim.org/tutorials?tut=add_laser) tutorial
+[Add a Sensor to a Robot](/tutorials?tut=add_laser) tutorial
 which introduces the use of the `<include>` element.
 
 The `<include>` element works by taking all the links from the included model

--- a/oculus/tutorial.md
+++ b/oculus/tutorial.md
@@ -25,7 +25,7 @@ sudo udevadm control --reload-rules
 
 Once Oculus VR SDK is installed, you should be able to compile Gazebo from source with Oculus Rift support.
 
-Follow [these](http://gazebosim.org/tutorials?tut=install_from_source&cat=install) instructions to compile Gazebo. During the execution of the `cmake` command, you should see this message confirming that the Oculus SDK is found:
+Follow [these](/tutorials?tut=install_from_source&cat=install) instructions to compile Gazebo. During the execution of the `cmake` command, you should see this message confirming that the Oculus SDK is found:
 
 ~~~
 -- checking for module 'OculusVR'

--- a/oculus/tutorial_3.md
+++ b/oculus/tutorial_3.md
@@ -27,7 +27,7 @@ sudo udevadm control --reload-rules
 
 Once Oculus VR SDK is installed, you should be able to compile Gazebo from source with Oculus Rift support.
 
-Follow [this](http://gazebosim.org/tutorials?tut=install_from_source&cat=install) instructions to compile Gazebo. During the execution of the `cmake` command, you should see this message confirming that the Oculus SDK is found:
+Follow [this](/tutorials?tut=install_from_source&cat=install) instructions to compile Gazebo. During the execution of the `cmake` command, you should see this message confirming that the Oculus SDK is found:
 
 ~~~
 -- checking for module 'OculusVR'

--- a/parallel/tutorial.md
+++ b/parallel/tutorial.md
@@ -76,7 +76,7 @@ The following snippet shows how to configure the physics engine with ode with 3 
  - **The name assigned to the physics tag will allow us to change the physics
  engine in runtime with the command `gz physics -o <name of the physics tag>`
  ( for example: `gz physics -o unthrottled1`)**.
- - **Visit the tutorial [Manage physics profiles](http://gazebosim.org/tutorials?tut=preset_manager&cat=physics)
+ - **Visit the tutorial [Manage physics profiles](/tutorials?tut=preset_manager&cat=physics)
  for more details about Gazebo physics parameters. These parameters affect the
  performance, accuracy, and general behavior of physics simulation. The
  physics preset manager interface offers a way to easily switch between a set
@@ -106,7 +106,7 @@ make
 sudo make install
 ```
 
-**For a detailed version of the install instructions please visit the [install tutorial](http://gazebosim.org/tutorials?tut=install_ubuntu).**
+**For a detailed version of the install instructions please visit the [install tutorial](/tutorials?tut=install_ubuntu).**
 
 ## Test Scenarios
 

--- a/performance_metrics/tutorial.md
+++ b/performance_metrics/tutorial.md
@@ -168,7 +168,7 @@ When you choose the `update rate` of a sensor you need to take in account if you
 defined in `max step size`. For example:
 
   - 1/250 = 0.004 it's fine using the default value.
-  - 1/400 = 0.0025. You will need to reduce the `max step size` to a number that is a factor of 0.0025, e.g. 0.0001, this will make the simulation slower. Changing this parameter has a side effect on the accuracy and speed of physics simulation, refer to this [tutorial](http://gazebosim.org/tutorials?tut=physics_params&cat=physics) for more information.
+  - 1/400 = 0.0025. You will need to reduce the `max step size` to a number that is a factor of 0.0025, e.g. 0.0001, this will make the simulation slower. Changing this parameter has a side effect on the accuracy and speed of physics simulation, refer to this [tutorial](/tutorials?tut=physics_params&cat=physics) for more information.
 
 In the following traces we included a IMU sensor at 400Hz. You can see that the `sim_update_rate` does not correspond with the defined value
 because the `max step size` does not have enough precision.

--- a/physics_params/tutorial.md
+++ b/physics_params/tutorial.md
@@ -245,7 +245,7 @@ With this `min_depth` determined, penetration between the two entities is update
 ## Friction parameters
 
 For torsional friction in ODE, please refer to the tutorial
-[here](http://gazebosim.org/tutorials?tut=torsional_friction&cat=physics).
+[here](/tutorials?tut=torsional_friction&cat=physics).
 
 Contact friction parameters for each surface are specified in the SDFormat
 `friction` element nested under `collision->surface->friction`

--- a/plugins_model/tutorial.md
+++ b/plugins_model/tutorial.md
@@ -1,6 +1,6 @@
 #Prerequisites
 
-  [Overview / HelloWorld](http://gazebosim.org/tutorials?tut=plugins_hello_world) Plugin Tutorial
+  [Overview / HelloWorld](/tutorials?tut=plugins_hello_world) Plugin Tutorial
 
 **Note:** If you're continuing from the previous tutorial, make sure you put in the proper `#include` lines for this tutorial that are listed below.
 
@@ -20,7 +20,7 @@ Plugin Code:
 
 ## Compiling the Plugin
 
-Assuming the reader has gone through the [Hello WorldPlugin tutorial](http://gazebosim.org/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Hello WorldPlugin tutorial](/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo8/examples/plugins/model_push/CMakeLists.txt' />
 

--- a/plugins_model/tutorial_1-9.md
+++ b/plugins_model/tutorial_1-9.md
@@ -1,6 +1,6 @@
 #Prerequisites
 
-  [Overview / HelloWorld](http://gazebosim.org/tutorials?tut=plugins_hello_world) Plugin Tutorial
+  [Overview / HelloWorld](/tutorials?tut=plugins_hello_world) Plugin Tutorial
 
 **Note:** If you're continuing from the previous tutorial, make sure you put in the proper `#include` lines for this tutorial that are listed below.
 
@@ -20,7 +20,7 @@ Plugin Code:
 
 ## Compiling the Plugin
 
-Assuming the reader has gone through the [Hello WorldPlugin tutorial](http://gazebosim.org/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Hello WorldPlugin tutorial](/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo_2.2/examples/plugins/model_push/CMakeLists.txt' />
 

--- a/plugins_random_velocity/tutorial-6.md
+++ b/plugins_random_velocity/tutorial-6.md
@@ -12,7 +12,7 @@ Once you have set the velocity magnitude, the direction is set on its own
 
 
 # Prerequisites
-[Hello World Plugin](http://gazebosim.org/tutorials?tut=plugins_hello_world&cat=write_plugin)
+[Hello World Plugin](/tutorials?tut=plugins_hello_world&cat=write_plugin)
 
 # Example
 1. Change your current working directory to the location of the worlds folder
@@ -95,7 +95,7 @@ above) and function declarations of the functions defined in
 
 `RandomVelocityPluginPrivate.cc` contains the private data pointer, in accordance
 with the
-[PIMPL idiom](http://gazebosim.org/tutorials?tut=contrib_code&cat=development#Style)
+[PIMPL idiom](/tutorials?tut=contrib_code&cat=development#Style)
 implementation (opaque pointers).
 The default initial values of all variables are set in it only.
 All other `#include`s are necessary for various parts of code. For example:
@@ -117,7 +117,7 @@ GZ_REGISTER_MODEL_PLUGIN(RandomVelocityPlugin)
 ~~~
 
 In the
-[hello world](http://gazebosim.org/tutorials/?tut=plugins_hello_world#HelloWorldPlugin!)
+[hello world](/tutorials/?tut=plugins_hello_world#HelloWorldPlugin!)
 tutorial we learned that plugins must be registered with the simulator using
 the `GZ_REGISTER_WORLD_PLUGIN` macro.
 

--- a/plugins_world/tutorial-7-8.md
+++ b/plugins_world/tutorial-7-8.md
@@ -1,7 +1,7 @@
 # Prerequisites:
 
- * [Model Manipulation](http://gazebosim.org/tutorials/?tut=plugins_model)
- * [Plugin Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world)
+ * [Model Manipulation](/tutorials/?tut=plugins_model)
+ * [Plugin Tutorial](/tutorials/?tut=plugins_hello_world)
 
 # Code:
 
@@ -49,7 +49,7 @@ The third method uses the message passing mechanism to insert a model. This meth
 
 ## Compile
 
-Assuming the reader has gone through the [Plugin Overview Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/factory.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Plugin Overview Tutorial](/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/factory.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo7/examples/plugins/factory/CMakeLists.txt' />
 

--- a/plugins_world/tutorial.md
+++ b/plugins_world/tutorial.md
@@ -1,7 +1,7 @@
 # Prerequisites:
 
- * [Model Manipulation](http://gazebosim.org/tutorials/?tut=plugins_model)
- * [Plugin Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world)
+ * [Model Manipulation](/tutorials/?tut=plugins_model)
+ * [Plugin Tutorial](/tutorials/?tut=plugins_hello_world)
 
 # Code:
 
@@ -49,7 +49,7 @@ The third method uses the message passing mechanism to insert a model. This meth
 
 ## Compile
 
-Assuming the reader has gone through the [Plugin Overview Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/factory.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Plugin Overview Tutorial](/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/factory.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo9/examples/plugins/factory/CMakeLists.txt' />
 

--- a/plugins_world/tutorial1_9.md
+++ b/plugins_world/tutorial1_9.md
@@ -1,7 +1,7 @@
 # Prerequisites:
 
- * [Model Manipulation](http://gazebosim.org/tutorials/?tut=plugins_model)
- * [Plugin Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world)
+ * [Model Manipulation](/tutorials/?tut=plugins_model)
+ * [Plugin Tutorial](/tutorials/?tut=plugins_hello_world)
 
 # Code:
 
@@ -49,7 +49,7 @@ The third method uses the message passing mechanism to insert a model. This meth
 
 ## Compile
 
-Assuming the reader has gone through the [Plugin Overview Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/factory.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Plugin Overview Tutorial](/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/factory.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo_2.2/examples/plugins/factory/CMakeLists.txt' />
 

--- a/plugins_world_properties/tutorial.md
+++ b/plugins_world_properties/tutorial.md
@@ -2,8 +2,8 @@ This plugin example programmatically modifies gravity.
 
 # Prerequisites:
 
- * [Model Manipulation](http://gazebosim.org/tutorials/?tut=plugins_model)
- * [Plugin Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world)
+ * [Model Manipulation](/tutorials/?tut=plugins_model)
+ * [Plugin Tutorial](/tutorials/?tut=plugins_hello_world)
 
 # Setup:
 
@@ -49,7 +49,7 @@ This message is then published to the "~/physics" topic.
 
 # Build
 
-Assuming the reader has gone through the [Plugin Overview Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/world_edit.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Plugin Overview Tutorial](/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/world_edit.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo9/examples/plugins/world_edit/CMakeLists.txt' />
 

--- a/plugins_world_properties/tutorial_1-9.md
+++ b/plugins_world_properties/tutorial_1-9.md
@@ -2,7 +2,7 @@
 
 This plugin example programmatically modifies the gravity.
 
-**Prerequisite**: See the [Plugins Overview](http://gazebosim.org/tutorials/?tut=plugins_hello_world) tutorial.
+**Prerequisite**: See the [Plugins Overview](/tutorials/?tut=plugins_hello_world) tutorial.
 
 ## Setup
 

--- a/plugins_world_properties/tutorial_2-2.md
+++ b/plugins_world_properties/tutorial_2-2.md
@@ -2,8 +2,8 @@ This plugin example programmatically modifies gravity.
 
 # Prerequisites:
 
- * [Model Manipulation](http://gazebosim.org/tutorials/?tut=plugins_model) 
- * [Plugin Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world)
+ * [Model Manipulation](/tutorials/?tut=plugins_model) 
+ * [Plugin Tutorial](/tutorials/?tut=plugins_hello_world)
 
 # Setup:
 
@@ -49,7 +49,7 @@ This message is then published to the "~/physics" topic.
 
 # Build
 
-Assuming the reader has gone through the [Plugin Overview Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/world_edit.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Plugin Overview Tutorial](/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/world_edit.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo_2.2/examples/plugins/world_edit/CMakeLists.txt' />
 

--- a/plugins_world_properties/tutorial_7.md
+++ b/plugins_world_properties/tutorial_7.md
@@ -2,8 +2,8 @@ This plugin example programmatically modifies gravity.
 
 # Prerequisites:
 
- * [Model Manipulation](http://gazebosim.org/tutorials/?tut=plugins_model)
- * [Plugin Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world)
+ * [Model Manipulation](/tutorials/?tut=plugins_model)
+ * [Plugin Tutorial](/tutorials/?tut=plugins_hello_world)
 
 # Setup:
 
@@ -49,7 +49,7 @@ This message is then published to the "~/physics" topic.
 
 # Build
 
-Assuming the reader has gone through the [Plugin Overview Tutorial](http://gazebosim.org/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/world_edit.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Plugin Overview Tutorial](/tutorials/?tut=plugins_hello_world), all that needs to be done in addition is save the above code as `~/gazebo_plugin_tutorial/world_edit.cc` and add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo7/examples/plugins/world_edit/CMakeLists.txt' />
 

--- a/process/tutorial.md
+++ b/process/tutorial.md
@@ -30,7 +30,7 @@ As of Gazebo 2.0.0, each number is incremented according to:
 
    3. 2 or more approvals are required for a pull request to be merged.
 
-   4. All pull requests must pass the [code checker](http://gazebosim.org/tutorials?tut=contrib_code&cat=development#CodeCheck), contain no build warnings, and [pass all the tests](http://gazebosim.org/tutorials?tut=contrib_code&cat=development#WriteTests).
+   4. All pull requests must pass the [code checker](/tutorials?tut=contrib_code&cat=development#CodeCheck), contain no build warnings, and [pass all the tests](/tutorials?tut=contrib_code&cat=development#WriteTests).
      
 ##Distinction between bugs and features
 

--- a/ros2_installing/tutorial.md
+++ b/ros2_installing/tutorial.md
@@ -3,7 +3,7 @@
 The set of ROS 2 packages for interfacing with Gazebo are contained within a
 meta package named `gazebo_ros_pkgs`.
 See
-[ROS 2 Overview](http://gazebosim.org/tutorials/?tut=ros2_overview)
+[ROS 2 Overview](/tutorials/?tut=ros2_overview)
 for background information before continuing here.
 
 The packages support ROS 2 Crystal and later and Gazebo 9 and later, and can be installed from
@@ -27,7 +27,7 @@ The current stable distribution is **Foxy**.
 ### Install Gazebo
 
 You can install Gazebo either from source or from pre-build packages. See
-[Install Gazebo](http://gazebosim.org/tutorials?cat=install).
+[Install Gazebo](/tutorials?cat=install).
 
 You should install Gazebo 9 or later. If installing from source, be sure to build the
 appropriate branch, such as `gazebo11` for Gazebo 11.

--- a/ros2_overview/tutorial.md
+++ b/ros2_overview/tutorial.md
@@ -1,7 +1,7 @@
 # ROS 2 integration overview
 
 > For ROS 1, see
-  [ROS integration overview](http://gazebosim.org/tutorials?tut=ros_overview).
+  [ROS integration overview](/tutorials?tut=ros_overview).
 
 Gazebo is a stand-alone application which can be used independently of ROS or
 ROS 2. The integration of Gazebo with either ROS version is done through a set

--- a/ros_advanced/tutorial.md
+++ b/ros_advanced/tutorial.md
@@ -2,7 +2,7 @@
 
 ## Dynamic Reconfigure
 
-Some of the physics properties can be adjusted within Gazebo as we described in the [modifying a world tutorial](http://gazebosim.org/tutorials?tut=modifying_world&cat=build_world). In addition, we can modify this properties using ROS's dynamic reconfigure mechanism.
+Some of the physics properties can be adjusted within Gazebo as we described in the [modifying a world tutorial](/tutorials?tut=modifying_world&cat=build_world). In addition, we can modify this properties using ROS's dynamic reconfigure mechanism.
 
 As an example, we'll invert the gravity in the simulation. Make sure you have the following installed for jade:
 

--- a/ros_comm/tutorial.md
+++ b/ros_comm/tutorial.md
@@ -4,7 +4,7 @@ Gazebo provides a set of ROS API's that allows users to modify and get informati
 
 ## Prerequisites
 
-If you would like to follow along with the examples make sure you have the RRBot setup as described in the [Using URDF in Gazebo](http://gazebosim.org/tutorials/?tut=ros_urdf). In this tutorial we'll have the RRBot "kick" a coke can using various techniques.
+If you would like to follow along with the examples make sure you have the RRBot setup as described in the [Using URDF in Gazebo](/tutorials/?tut=ros_urdf). In this tutorial we'll have the RRBot "kick" a coke can using various techniques.
 
 We'll assume you have Gazebo already launched using:
 
@@ -114,7 +114,7 @@ These services allow the user to spawn and destroy models dynamically in simulat
 
 ### Spawn Model
 
-A helper script called `spawn_model` is provided for calling the model spawning services offered by `gazebo_ros`. The most practical method for spawning a model using the service call method is with a `roslaunch` file. Details are provided in the tutorial [Using roslaunch Files to Spawn Models](http://gazebosim.org/tutorials/?tut=ros_roslaunch). There are many ways to use spawn_model to add URDFs and SDFs to Gazebo. The following are a few of the examples:
+A helper script called `spawn_model` is provided for calling the model spawning services offered by `gazebo_ros`. The most practical method for spawning a model using the service call method is with a `roslaunch` file. Details are provided in the tutorial [Using roslaunch Files to Spawn Models](/tutorials/?tut=ros_roslaunch). There are many ways to use spawn_model to add URDFs and SDFs to Gazebo. The following are a few of the examples:
 
 Spawn a URDF from file - first convert .xacro file to .xml then spawn:
 
@@ -124,7 +124,7 @@ rosrun gazebo_ros spawn_model -file `rospack find rrbot_description`/urdf/rrbot.
 ~~~
 
 URDF from parameter server using roslaunch and xacro:
-See [Using roslaunch Files to Spawn Models](http://gazebosim.org/tutorials/?tut=ros_roslaunch)
+See [Using roslaunch Files to Spawn Models](/tutorials/?tut=ros_roslaunch)
 
 SDF from local model database:
 
@@ -412,4 +412,4 @@ rosservice call gazebo/unpause_physics
 ~~~
 
 ## Next Steps
-Learn how to create custom [ROS plugins for Gazebo](http://gazebosim.org/tutorials/?tut=ros_plugins).
+Learn how to create custom [ROS plugins for Gazebo](/tutorials/?tut=ros_plugins).

--- a/ros_control/tutorial.md
+++ b/ros_control/tutorial.md
@@ -19,10 +19,10 @@ An overview of the relationship between simulation, hardware, controllers and tr
 
 This tutorial builds off of many of the concepts in the previous tutorials.
 We will again be using the RRBot that was setup in the
-[Using URDF in Gazebo](http://gazebosim.org/tutorials/?tut=ros_urdf) tutorial, as an example for the plugins covered here.
+[Using URDF in Gazebo](/tutorials/?tut=ros_urdf) tutorial, as an example for the plugins covered here.
 
 Make sure you have already installed ros\_control, ros\_controllers, and their dependencies as described in the
-[installation instructions](http://gazebosim.org/tutorials?tut=ros_installing&cat=connect_ros).
+[installation instructions](/tutorials?tut=ros_installing&cat=connect_ros).
 
 # Usage
 
@@ -386,4 +386,4 @@ The example code used for the RRBot in this tutorial is available in the reposit
 
 # Next Steps
 
-Learn about ROS message and service calls that are available for use with Gazebo in the tutorial [ROS Communication with Gazebo](http://gazebosim.org/tutorials/?tut=ros_comm).
+Learn about ROS message and service calls that are available for use with Gazebo in the tutorial [ROS Communication with Gazebo](/tutorials/?tut=ros_comm).

--- a/ros_depth_camera/tutorial.md
+++ b/ros_depth_camera/tutorial.md
@@ -15,7 +15,7 @@ quickly using computer vision in ROS and Gazebo.
 
 ### Prerequisites
 
-You should [install gazebo\_ros\_pkgs](http://gazebosim.org/tutorials?tut=ros_installing&cat=connect_ros)
+You should [install gazebo\_ros\_pkgs](/tutorials?tut=ros_installing&cat=connect_ros)
 before doing this tutorial.
 
 ## Create a Gazebo Model with a Depth Camera Plugin
@@ -36,7 +36,7 @@ sensor from `gazebo_models` repository for you, so all you have to do is
 and unzip it.
 
 Alternatively, you can follow the
-[model contribution tutorial](http://gazebosim.org/tutorials?tut=model_contrib&cat=build_robot)
+[model contribution tutorial](/tutorials?tut=model_contrib&cat=build_robot)
 to make your own camera from scratch, or you can clone the `gazebo_models`
 repository and copy one of the sensors from there.
 
@@ -49,7 +49,7 @@ in the `model.sdf` file.
 Now you need to add the ROS plugin to publish depth camera information and
 output to ROS topics. A list of ROS plugins, with example code, can be found in
 the
-[plugins tutorial](http://gazebosim.org/tutorials?tut=ros_gzplugins&cat=connect_ros).
+[plugins tutorial](/tutorials?tut=ros_gzplugins&cat=connect_ros).
 
 In this tutorial, you'll be using the generic "Openni Kinect" plugin. You can
 (and should) use this plugin for other types of depth cameras besides the Kinect

--- a/ros_gzplugins/tutorial.md
+++ b/ros_gzplugins/tutorial.md
@@ -6,13 +6,13 @@ In this tutorial we explain both how to setup preexisting plugins and how to cre
 
 ## Prerequisites
 
-Make sure you have the RRBot setup as described in the [previous tutorial on URDFs](http://gazebosim.org/tutorials/?tut=ros_urdf).
+Make sure you have the RRBot setup as described in the [previous tutorial on URDFs](/tutorials/?tut=ros_urdf).
 Also make sure you have understood the use of the `<gazebo>` element within the URDF description, from that same tutorial.
 
 ## Plugin Types
 
 Gazebo supports
-[several plugin types](http://gazebosim.org/tutorials?tut=plugins_hello_world&cat=write_plugin),
+[several plugin types](/tutorials?tut=plugins_hello_world&cat=write_plugin),
 and all of them can be connected to ROS, but only a few types can be referenced through a URDF file:
 
   1. [ModelPlugins](http://osrf-distributions.s3.amazonaws.com/gazebo/api/dev/classgazebo_1_1ModelPlugin.html), to provide access to the [physics::Model](http://osrf-distributions.s3.amazonaws.com/gazebo/api/dev/classgazebo_1_1physics_1_1Model.html) API
@@ -369,7 +369,7 @@ In this code example there is both a left and right camera:
 </gazebo>
 ~~~
 
-You can find a more detailed description for configuring a depth camera in [Use a Gazebo Depth Camera with ROS](http://gazebosim.org/tutorials/?tut=ros_depth_camera).
+You can find a more detailed description for configuring a depth camera in [Use a Gazebo Depth Camera with ROS](/tutorials/?tut=ros_depth_camera).
 
 ## GPU Laser
 
@@ -791,4 +791,4 @@ If a 3rd party plugin is useful and generic enough, please consider pulling it i
 # Next Steps
 
 Next we will analyze the `ros_control` packages integrated with Gazebo for tight controller/actuator/simulator integration
-[Actuators, controllers, and ros_control](http://gazebosim.org/tutorials/?tut=ros_control).
+[Actuators, controllers, and ros_control](/tutorials/?tut=ros_control).

--- a/ros_installing/tutorial.md
+++ b/ros_installing/tutorial.md
@@ -2,13 +2,13 @@
 
 The set of ROS packages for interfacing with Gazebo are contained within a
 new meta package (catkin's version of stacks) named `gazebo_ros_pkgs`.
-See [Overview of new ROS integration](http://gazebosim.org/tutorials/?tut=ros_overview)
+See [Overview of new ROS integration](/tutorials/?tut=ros_overview)
 for background information before continuing here.
 
 These instructions are for using the Gazebo versions that are fully integrated
 with ROS [Noetic](http://www.ros.org/wiki/noetic),
 [Melodic](http://www.ros.org/wiki/melodic) and ROS.  It is recommended to first
-read [Which combination of ROS/Gazebo version to use](http://gazebosim.org/tutorials/?tut=ros_wrapper_versions)
+read [Which combination of ROS/Gazebo version to use](/tutorials/?tut=ros_wrapper_versions)
 before going on with this tutorial. Depending on your needs, you could need an
 alternative installation.
 
@@ -28,7 +28,7 @@ See the [ROS installation page](http://www.ros.org/wiki/ROS/Installation) for mo
 
 You can install Gazebo either from source or from pre-build Ubuntu debians.
 
-See [Install Gazebo](http://gazebosim.org/tutorials?cat=install). If installing from source, be sure to build the `gazebo_X.Y` (X.Y being your desired version) branch.
+See [Install Gazebo](/tutorials?cat=install). If installing from source, be sure to build the `gazebo_X.Y` (X.Y being your desired version) branch.
 
 #### Test that stand-alone Gazebo works
 

--- a/ros_overview/tutorial.md
+++ b/ros_overview/tutorial.md
@@ -1,7 +1,7 @@
 # Tutorial: ROS integration overview
 
 > For ROS 2, see
-  [ROS 2 integration overview](http://gazebosim.org/tutorials?tut=ros2_overview).
+  [ROS 2 integration overview](/tutorials?tut=ros2_overview).
 
 To achieve ROS integration with stand-alone Gazebo, a set of ROS packages named
 [gazebo\_ros\_pkgs](http://ros.org/wiki/gazebo_ros_pkgs) provides wrappers
@@ -29,7 +29,7 @@ The following guidelines will help you upgrade your Gazebo-dependent packages fr
 
 Some changes are required in previously created roslaunch files for starting Gazebo.
 The best way to update these packages is to review the
-[Using roslaunch files to spawn models in Gazebo](http://gazebosim.org/tutorials?tut=ros_roslaunch&cat=connect_ros) tutorial.
+[Using roslaunch files to spawn models in Gazebo](/tutorials?tut=ros_roslaunch&cat=connect_ros) tutorial.
 In a nutshell:
 
 - Within roslaunch files, `pkg="gazebo"` needs to be now renamed to `pkg="gazebo_ros"`
@@ -97,6 +97,6 @@ rosrun gazebo_ros debug
 </pre>
 
 These nodes are better documented in the tutorial
-[Using roslaunch files to spawn models in Gazebo](http://gazebosim.org/tutorials?tut=ros_roslaunch&cat=connect_ros).
+[Using roslaunch files to spawn models in Gazebo](/tutorials?tut=ros_roslaunch&cat=connect_ros).
 
-Continue to [Installing gazebo_ros Packages](http://gazebosim.org/tutorials?tut=ros_installing&cat=connect_ros).
+Continue to [Installing gazebo_ros Packages](/tutorials?tut=ros_installing&cat=connect_ros).

--- a/ros_plugins/tutorial.md
+++ b/ros_plugins/tutorial.md
@@ -13,7 +13,7 @@ catkin_create_pkg gazebo_tutorials gazebo_ros roscpp
 
 ## Create the Plugin
 
-Create a very simple plugin as described [here](http://gazebosim.org/tutorials?tut=plugins_hello_world&cat=write_plugin) and save the file as `gazebo_tutorials/src/simple_world_plugin.cpp`:
+Create a very simple plugin as described [here](/tutorials?tut=plugins_hello_world&cat=write_plugin) and save the file as `gazebo_tutorials/src/simple_world_plugin.cpp`:
 
 ~~~
 #include <gazebo/common/Plugin.hh>
@@ -168,7 +168,7 @@ A template is available to help you quickly get a Gazebo-ROS plugin working:
 
 ## Adding Functionality
 
-To make your plugin do something useful with Gazebo and ROS, we suggest you read the ROS-agnostic tutorials on [Plugins](http://gazebosim.org/tutorials/?cat=write_plugin).
+To make your plugin do something useful with Gazebo and ROS, we suggest you read the ROS-agnostic tutorials on [Plugins](/tutorials/?cat=write_plugin).
 
 ## ROS Node Note
 
@@ -182,4 +182,4 @@ or use the generic empty.world launch file. The `gazebo_ros/src/gazebo_ros_api_p
 
 ## Next Steps
 
-For miscellaneous Gazebo-ROS tricks see [Advanced ROS integration](http://gazebosim.org/tutorials/?tut=ros_advanced)
+For miscellaneous Gazebo-ROS tricks see [Advanced ROS integration](/tutorials/?tut=ros_advanced)

--- a/ros_roslaunch/tutorial.md
+++ b/ros_roslaunch/tutorial.md
@@ -114,7 +114,7 @@ Continuing with our examination of the `mud_world.launch` file, we will now look
 
 In this world file snippet you can see that three models are referenced. The three models are searched for within your local Gazebo Model Database. If not found there, they are automatically pulled from Gazebo's online database.
 
-You can learn more about world files in the [Build A World](http://gazebosim.org/tutorials?cat=build_world) tutorial.
+You can learn more about world files in the [Build A World](/tutorials?cat=build_world) tutorial.
 
 #### Finding World Files On Your Computer
 World files are found within the `/worlds` directory of your Gazebo resource path. The location of this path depends on how you installed Gazebo and the type of system your are on. To find the location of your Gazebo resources, use the following command:
@@ -448,4 +448,4 @@ To check the media path that will be picked up by gazebo.
 
 ## Next Steps
 
-Now that you know how to create `roslaunch` files that open Gazebo, world files and URDF models, you are now ready to create your own Gazebo-ready URDF model in the tutorial [Using A URDF In Gazebo](http://gazebosim.org/tutorials/?tut=ros_urdf)
+Now that you know how to create `roslaunch` files that open Gazebo, world files and URDF models, you are now ready to create your own Gazebo-ready URDF model in the tutorial [Using A URDF In Gazebo](/tutorials/?tut=ros_urdf)

--- a/ros_urdf/tutorial.md
+++ b/ros_urdf/tutorial.md
@@ -70,7 +70,7 @@ cd ..
 catkin_make
 </pre>
 
-If any of this is unfamiliar, be sure you have read the previous [ROS Overview Tutorials](http://gazebosim.org/tutorials?tut=ros_overview).
+If any of this is unfamiliar, be sure you have read the previous [ROS Overview Tutorials](/tutorials?tut=ros_overview).
 
 ### View in Rviz
 To check if everything is working, launch RRBot in Rviz:
@@ -92,7 +92,7 @@ It is important that while converting your robot to work in Gazebo,
 you don't break Rviz or other ROS-application functionality,
 so its nice to occasionally test your robot in Rviz to make sure everything still works.
 
-The [gazebo\_ros\_control](http://gazebosim.org/tutorials?tut=ros_control)
+The [gazebo\_ros\_control](/tutorials?tut=ros_control)
 tutorial will explain how to use Rviz to monitor the state of your simulated
 robot by publishing `/joint_states` directly from Gazebo.
 In the previous example, the RRBot in Rviz is getting its `/joint_states`
@@ -169,7 +169,7 @@ td {padding: 5px;}
 </tr>
 </table>
 
-Elements within a `<gazebo>` tag that are not in the above table are directly inserted into the SDF `<model>` tag for the generated SDF. This is particularly useful for plugins, as discussed in the [ROS Motor and Sensor Plugins](http://gazebosim.org/tutorials?tut=ros_gzplugins) tutorial.
+Elements within a `<gazebo>` tag that are not in the above table are directly inserted into the SDF `<model>` tag for the generated SDF. This is particularly useful for plugins, as discussed in the [ROS Motor and Sensor Plugins](/tutorials?tut=ros_gzplugins) tutorial.
 
 ## Rigidly Fixing A Model to the World
 If you would like your URDF model to be permanently attached to the world frame (the ground plane), you must create a "world" link and a joint that fixes it to the base of your model. RRBot accomplishes this with the following:
@@ -381,7 +381,7 @@ List of elements that are individually parsed:
 </tr>
 </table>
 
-Similar to `<gazebo>` elements for `<robot>`, any arbitrary blobs that are not parsed according to the table above are inserted into the the corresponding `<link>` element in the SDF. This is particularly useful for plugins, as discussed in the [ROS Motor and Sensor Plugins](http://gazebosim.org/tutorials?tut=ros_gzplugins) tutorial.
+Similar to `<gazebo>` elements for `<robot>`, any arbitrary blobs that are not parsed according to the table above are inserted into the the corresponding `<link>` element in the SDF. This is particularly useful for plugins, as discussed in the [ROS Motor and Sensor Plugins](/tutorials?tut=ros_gzplugins) tutorial.
 
 ### RRBot Example of <gazebo> element
 
@@ -476,7 +476,7 @@ The cfmDamping element is deprecated and should be changed to implicitSpringDamp
 </tr>
 </table>
 
-Again, similar to `<gazebo>` elements for `<robot>` and `<link>`, any arbitrary blobs that are not parsed according to the table above are inserted into the the corresponding `<joint>` element in the SDF. This is particularly useful for plugins, as discussed in the [ROS Motor and Sensor Plugins](http://gazebosim.org/tutorials?tut=ros_gzplugins) tutorial.
+Again, similar to `<gazebo>` elements for `<robot>` and `<link>`, any arbitrary blobs that are not parsed according to the table above are inserted into the the corresponding `<joint>` element in the SDF. This is particularly useful for plugins, as discussed in the [ROS Motor and Sensor Plugins](/tutorials?tut=ros_gzplugins) tutorial.
 
 ## Verifying the Gazebo Model Works
 
@@ -496,7 +496,7 @@ Note: in Gazebo version 1.9 and greater, some of the debug info has been moved t
 
 ## Viewing the URDF In Gazebo
 
-Viewing the RRBot in Gazebo was already covered at the beginning of this tutorial. For your own custom robot, we assume its URDF lives in a ROS package named `MYROBOT_description` in the subfolder `/urdf`. The method to open a URDF from that location into Gazebo using ROS was covered in the previous tutorial, [Using roslaunch Files to Spawn Models](http://gazebosim.org/tutorials?tut=ros_roslaunch). If you have not completed that tutorial, do so now.
+Viewing the RRBot in Gazebo was already covered at the beginning of this tutorial. For your own custom robot, we assume its URDF lives in a ROS package named `MYROBOT_description` in the subfolder `/urdf`. The method to open a URDF from that location into Gazebo using ROS was covered in the previous tutorial, [Using roslaunch Files to Spawn Models](/tutorials?tut=ros_roslaunch). If you have not completed that tutorial, do so now.
 
 From that tutorial you should have two ROS packages for your custom robot: `MYROBOT_description` and `MYROBOT_gazebo`. To view your robot and test it in Gazebo, you should be able to now run something like:
 
@@ -514,12 +514,12 @@ If your robot model behaves unexpectedly within Gazebo, it is likely because you
 
 If you have a common robot that other's might want to use in Gazebo,
 you are encouraged to add your URDF to the
-[Gazebo Model Database](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot).
+[Gazebo Model Database](/tutorials?tut=model_structure&cat=build_robot).
 It is an online server that Gazebo connects to to pull down models from the internet.
 Its Mercurial repository is located on [GitHub](https://github.com/osrf/gazebo_models).
-See [Gazebo Model Database](http://gazebosim.org/tutorials?tut=model_contrib&cat=build_robot)
+See [Gazebo Model Database](/tutorials?tut=model_contrib&cat=build_robot)
 documentation for how to submit a pull request to have your robot added to the database.
 
 ## Next steps
 
-You have now learned how to use ROS packages containing URDFs with Gazebo, and how to convert your custom URDF to work in Gazebo. You are now ready to learn about adding plugins to your URDF so that different aspects of your robot and the simulated environment can be controlled. See [ROS Motor and Sensor Plugins](http://gazebosim.org/tutorials?tut=ros_gzplugins).
+You have now learned how to use ROS packages containing URDFs with Gazebo, and how to convert your custom URDF to work in Gazebo. You are now ready to learn about adding plugins to your URDF so that different aspects of your robot and the simulated environment can be controlled. See [ROS Motor and Sensor Plugins](/tutorials?tut=ros_gzplugins).

--- a/ros_wrapper_versions/tutorial.md
+++ b/ros_wrapper_versions/tutorial.md
@@ -8,7 +8,7 @@ It is recommended to read it before installing the Gazebo ROS wrappers.
 
 If you are planning on using a specific version of ROS and don't have a reason
 to use a specific version of Gazebo, you should proceed with the
-[Installing gazebo\_ros\_pkgs](http://gazebosim.org/tutorials?tut=ros_installing&cat=connect_ros)
+[Installing gazebo\_ros\_pkgs](/tutorials?tut=ros_installing&cat=connect_ros)
 tutorial which explains how to install the fully supported version of gazebo
 by ROS.
 

--- a/simple_gripper/tutorial.md
+++ b/simple_gripper/tutorial.md
@@ -4,12 +4,12 @@ This tutorial describes how to make a simple two-bar pinching gripper by
 editing SDF files.
 
 For editing models graphically, see the
-[Model Editor](http://gazebosim.org/tutorials?tut=model_editor&cat=build_robot)
+[Model Editor](/tutorials?tut=model_editor&cat=build_robot)
 tutorial.
 
 # Setup your model directory
 
-Reference [Model Database documentation](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot) and [SDF](http://gazebosim.org/sdf) documentation for this tutorial.
+Reference [Model Database documentation](/tutorials?tut=model_structure&cat=build_robot) and [SDF](http://gazebosim.org/sdf) documentation for this tutorial.
 
 # Make the model
 
@@ -155,4 +155,4 @@ file:
 
 # Next
 
-[Next: Attach Gripper to Robot](http://gazebosim.org/tutorials/?tut=attach_gripper)
+[Next: Attach Gripper to Robot](/tutorials/?tut=attach_gripper)

--- a/simple_gripper/tutorial_1-9.md
+++ b/simple_gripper/tutorial_1-9.md
@@ -4,7 +4,7 @@ This tutorial describes how to make a simple two-bar pinching gripper.
 
 # Setup your model directory
 
-Reference [Model Database documentation](http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot) and [SDF](http://gazebosim.org/sdf) documentation for this tutorial.
+Reference [Model Database documentation](/tutorials?tut=model_structure&cat=build_robot) and [SDF](http://gazebosim.org/sdf) documentation for this tutorial.
 
 # Make the model
 
@@ -139,4 +139,4 @@ Reference [Model Database documentation](http://gazebosim.org/tutorials?tut=mode
 
 # Next
 
-[Next: Attach Gripper to Robot](http://gazebosim.org/tutorials/?tut=attach_gripper)
+[Next: Attach Gripper to Robot](/tutorials/?tut=attach_gripper)

--- a/stereo_glasses/tutorial.md
+++ b/stereo_glasses/tutorial.md
@@ -52,7 +52,7 @@ This tutorial assumes that you will be using Ubuntu.
     sudo apt-get install nvidia-settings
     ~~~
 
-1. Gazebo [compiled from source](http://gazebosim.org/tutorials?tut=install_from_source&cat=install). You may use the Gazebo6 debians when they are made available on July 27, 2015.
+1. Gazebo [compiled from source](/tutorials?tut=install_from_source&cat=install). You may use the Gazebo6 debians when they are made available on July 27, 2015.
 
 1. If you are using the Unity desktop environment, stereo probably won't work. Install Gnome Classic:
 

--- a/system_plugin/tutorial.md
+++ b/system_plugin/tutorial.md
@@ -1,6 +1,6 @@
 #Prerequisites
 
-  [Overview / HelloWorld](http://gazebosim.org/tutorials?tut=plugins_hello_world) Plugin Tutorial
+  [Overview / HelloWorld](/tutorials?tut=plugins_hello_world) Plugin Tutorial
 
 # Overview
 
@@ -40,7 +40,7 @@ On the first `Update`, we get a pointer to the user camera (the camera used in t
 
 ## Compiling Camera Plugin
 
-Assuming the reader has gone through the [Hello WorldPlugin tutorial](http://gazebosim.org/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Hello WorldPlugin tutorial](/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo9/examples/plugins/system_gui_plugin/CMakeLists.txt' />
 

--- a/system_plugin/tutorial_5-0.md
+++ b/system_plugin/tutorial_5-0.md
@@ -1,6 +1,6 @@
 #Prerequisites
 
-  [Overview / HelloWorld](http://gazebosim.org/tutorials?tut=plugins_hello_world) Plugin Tutorial
+  [Overview / HelloWorld](/tutorials?tut=plugins_hello_world) Plugin Tutorial
 
 # Overview
 
@@ -40,7 +40,7 @@ On the first `Update`, we get a pointer to the user camera (the camera used in t
 
 ## Compiling Camera Plugin
 
-Assuming the reader has gone through the [Hello WorldPlugin tutorial](http://gazebosim.org/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Hello WorldPlugin tutorial](/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo5/examples/plugins/system_gui_plugin/CMakeLists.txt' />
 

--- a/system_plugin/tutorial_7-0.md
+++ b/system_plugin/tutorial_7-0.md
@@ -1,6 +1,6 @@
 #Prerequisites
 
-  [Overview / HelloWorld](http://gazebosim.org/tutorials?tut=plugins_hello_world) Plugin Tutorial
+  [Overview / HelloWorld](/tutorials?tut=plugins_hello_world) Plugin Tutorial
 
 # Overview
 
@@ -40,7 +40,7 @@ On the first `Update`, we get a pointer to the user camera (the camera used in t
 
 ## Compiling Camera Plugin
 
-Assuming the reader has gone through the [Hello WorldPlugin tutorial](http://gazebosim.org/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Hello WorldPlugin tutorial](/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo7/examples/plugins/system_gui_plugin/CMakeLists.txt' />
 

--- a/system_plugin/tutorial_8-0.md
+++ b/system_plugin/tutorial_8-0.md
@@ -1,6 +1,6 @@
 #Prerequisites
 
-  [Overview / HelloWorld](http://gazebosim.org/tutorials?tut=plugins_hello_world) Plugin Tutorial
+  [Overview / HelloWorld](/tutorials?tut=plugins_hello_world) Plugin Tutorial
 
 # Overview
 
@@ -40,7 +40,7 @@ On the first `Update`, we get a pointer to the user camera (the camera used in t
 
 ## Compiling Camera Plugin
 
-Assuming the reader has gone through the [Hello WorldPlugin tutorial](http://gazebosim.org/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
+Assuming the reader has gone through the [Hello WorldPlugin tutorial](/tutorials?tut=plugins_hello_world) all that needs to be done is to add the following lines to `~/gazebo_plugin_tutorial/CMakeLists.txt`
 
 <include from="/add_library/" src='http://github.com/osrf/gazebo/raw/gazebo8/examples/plugins/system_gui_plugin/CMakeLists.txt' />
 

--- a/torsional_friction/tutorial.md
+++ b/torsional_friction/tutorial.md
@@ -1,5 +1,5 @@
 This tutorial is about torsional friction. For translational friction, see
-[this](http://gazebosim.org/tutorials?tut=friction) tutorial.
+[this](/tutorials?tut=friction) tutorial.
 
 # Overview
 

--- a/wide_angle_camera/tutorial.md
+++ b/wide_angle_camera/tutorial.md
@@ -3,7 +3,7 @@
 This tutorial shows how to create use and setup wide-angle camera sensor.
 The difference between regular camera and wide-angle is in projection types:
 The regular camera sensor uses only [pinhole projection](https://en.wikipedia.org/wiki/Pinhole_camera), while wide-anglecamera have much more options.
-For moderate view angle lens distortion could be simulated, as described in [corresponding tutorial](http://gazebosim.org/tutorials?tut=camera_distortion).
+For moderate view angle lens distortion could be simulated, as described in [corresponding tutorial](/tutorials?tut=camera_distortion).
 But if you need a camera with fisheye, or other type of wide-angle lens, whose field of view is `120°`, `180°` or `270°` then you should use wide-angle camera sensor.
 
 


### PR DESCRIPTION
The Gazebo Classic tutorials are now hosted at https://classic.gazebosim.org, but there are many Markdown links in the tutorials that point explicitly to http://gazebosim.org. This pull request fixes the README link to point to http://classic.gazebosim.org/tutorials and changes the beginning of all Markdown links that start with `http://gazebosim.org/tutorials` with `/tutorials`, which should automatically refer to the same host.

Alternative: explicitly replace all references to gazebosim.org with classic.gazebosim.org