### PR TITLE
Fix gz-common API link in profiler tutorial

### DIFF
--- a/profiler/tutorial.md
+++ b/profiler/tutorial.md
@@ -1,6 +1,6 @@
 # Profiler
 
-Gazebo 11 uses the [Ignition Common Profiler](https://ignitionrobotics.org/api/common/3.5/profiler.html) to check and visualize the performance of the different threads, functions and methods.
+Gazebo 11 uses the [gz-common Profiler](https://gazebosim.org/api/common/3/profiler.html) to check and visualize the performance of the different threads, functions and methods.
 
 Gazebo 9 uses an internal fork of Ignition Common's profiler.
 


### PR DESCRIPTION
Fixes the first link on the following page:

* https://classic.gazebosim.org/tutorials?tut=profiler&cat=tools_utilities